### PR TITLE
fix: update GitHub repo links to correct repository

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -54,7 +54,7 @@ const config: Config = {
           position: 'right',
         },
         {
-          href: 'https://github.com/pierredosne/my-team',
+          href: 'https://github.com/pierredosne-fin/data-platform-tonkatsu',
           label: 'GitHub',
           position: 'right',
         },

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -23,7 +23,7 @@ function Hero() {
           </Link>
           <Link
             className={styles.ctaSecondary}
-            href="https://github.com/pierredosne/my-team"
+            href="https://github.com/pierredosne-fin/data-platform-tonkatsu"
           >
             <svg width="18" height="18" viewBox="0 0 24 24" fill="currentColor" aria-hidden>
               <path d="M12 2C6.477 2 2 6.484 2 12.017c0 4.425 2.865 8.18 6.839 9.504.5.092.682-.217.682-.483 0-.237-.008-.868-.013-1.703-2.782.605-3.369-1.343-3.369-1.343-.454-1.158-1.11-1.466-1.11-1.466-.908-.62.069-.608.069-.608 1.003.07 1.531 1.032 1.531 1.032.892 1.53 2.341 1.088 2.91.832.092-.647.35-1.088.636-1.338-2.22-.253-4.555-1.113-4.555-4.951 0-1.093.39-1.988 1.029-2.688-.103-.253-.446-1.272.098-2.65 0 0 .84-.27 2.75 1.026A9.564 9.564 0 0112 6.844a9.59 9.59 0 012.504.337c1.909-1.296 2.747-1.027 2.747-1.027.546 1.379.202 2.398.1 2.651.64.7 1.028 1.595 1.028 2.688 0 3.848-2.339 4.695-4.566 4.943.359.309.678.92.678 1.855 0 1.338-.012 2.419-.012 2.747 0 .268.18.58.688.482A10.019 10.019 0 0022 12.017C22 6.484 17.522 2 12 2z" />
@@ -166,7 +166,7 @@ function CTA() {
           <Link className={styles.ctaPrimary} to="/docs/intro">
             Get started
           </Link>
-          <Link className={styles.ctaSecondary} href="https://github.com/pierredosne/my-team">
+          <Link className={styles.ctaSecondary} href="https://github.com/pierredosne-fin/data-platform-tonkatsu">
             View on GitHub
           </Link>
         </div>


### PR DESCRIPTION
## Summary
- Replace placeholder GitHub URL (`pierredosne/my-team`) with the correct repo URL (`pierredosne-fin/data-platform-tonkatsu`) in 3 places
- Files updated: `docs/docusaurus.config.ts` (navbar link) and `docs/src/pages/index.tsx` (hero + CTA buttons)

## Test plan
- [ ] Visit the docs site and verify the GitHub buttons link to the correct repository

🤖 Generated with [Claude Code](https://claude.ai/claude-code)