### PR TITLE
fix: add setup-buildx-action to fix GHA cache in develop CI

### DIFF
--- a/.github/workflows/develop.yml
+++ b/.github/workflows/develop.yml
@@ -54,6 +54,9 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Docker metadata
         id: meta
         uses: docker/metadata-action@v5


### PR DESCRIPTION
## Summary

- The `Develop` workflow was failing with: `Cache export is not supported for the docker driver`
- GHA cache (`type=gha`) requires the `docker-container` buildx driver, not the default `docker` driver
- Added `docker/setup-buildx-action@v3` before the build step to set up the correct driver

## Root cause

`docker/build-push-action` with `cache-from/cache-to: type=gha` requires BuildKit running as a standalone container (the `docker-container` driver). The default runner only has the `docker` driver which does not support GHA cache export.

## Test plan

- [ ] Merge and verify the `Develop` workflow completes successfully on `develop` branch
- [ ] Confirm Docker image is pushed to `ghcr.io/pierredosne-fin/data-platform-tonkatsu` with `dev-*` tags

🤖 Generated with [Claude Code](https://claude.com/claude-code)