### PR TITLE
fix: trigger docs deploy on any push to main

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -2,9 +2,7 @@ name: Deploy Docs
 
 on:
   push:
-    branches: [develop]
-    paths:
-      - 'docs/**'
+    branches: [main]
 
 concurrency:
   group: pages


### PR DESCRIPTION
## What

Fixes two bugs in `.github/workflows/docs.yml`:

1. Trigger was still `branches: [develop]` — changed to `[main]`
2. `paths: docs/**` filter was blocking the workflow unless a `docs/` file changed — removed

## Result

Every push/merge to `main` now builds the Docusaurus site and deploys to GitHub Pages unconditionally.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)