### PR TITLE
fix: set correct baseUrl for GitHub Pages

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -7,8 +7,8 @@ const config: Config = {
   tagline: 'A virtual office for Claude Code agents',
   favicon: 'img/tonkatsu.png',
 
-  url: 'https://my-team.dev',
-  baseUrl: '/',
+  url: 'https://pierredosne-fin.github.io',
+  baseUrl: '/data-platform-tonkatsu/',
 
   onBrokenLinks: 'throw',
   markdown: {


### PR DESCRIPTION
## What

Fixes the Docusaurus rendering error:
> "Your Docusaurus site did not load properly. A very common reason is a wrong site baseUrl configuration."

## Changes in `docs/docusaurus.config.ts`

| Field | Before | After |
|-------|--------|-------|
| `url` | `https://my-team.dev` | `https://pierredosne-fin.github.io` |
| `baseUrl` | `/` | `/data-platform-tonkatsu/` |

GitHub Pages serves the site at `https://pierredosne-fin.github.io/data-platform-tonkatsu/` — the baseUrl must match.

🤖 Generated with [Claude Code](https://claude.ai/claude-code)