### PR TITLE
fix: use useBaseUrl/require for doc image paths

### DIFF
--- a/docs/docs/intro.md
+++ b/docs/docs/intro.md
@@ -5,7 +5,7 @@ sidebar_position: 1
 ---
 
 <div style={{textAlign: 'center', margin: '2rem 0 2.5rem'}}>
-  <img src="/img/tonkatsu.png" alt="Tonkatsu" style={{height: '140px', borderRadius: '0.75rem'}} />
+  <img src={require("@site/static/img/tonkatsu.png").default} alt="Tonkatsu" style={{height: '140px', borderRadius: '0.75rem'}} />
   <h1 style={{fontSize: '2.5rem', fontWeight: 800, letterSpacing: '-0.03em', marginTop: '1rem', marginBottom: '0.25rem'}}>Tonkatsu</h1>
   <p style={{fontSize: '1.1rem', opacity: 0.6, marginBottom: 0}}>A virtual office for AI assistants</p>
 </div>

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
+import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import styles from './index.module.css';
 
@@ -8,7 +9,7 @@ function Hero() {
   return (
     <section className={styles.hero}>
       <div className={styles.heroInner}>
-        <img src="/img/tonkatsu.png" alt="Tonkatsu" className={styles.heroLogo} />
+        <img src={useBaseUrl('/img/tonkatsu.png')} alt="Tonkatsu" className={styles.heroLogo} />
         <h1 className={styles.heroTitle}>
           Your AI team,{' '}
           <span className={styles.heroTitleAccent}>always at work</span>
@@ -43,7 +44,7 @@ function Hero() {
               <span className={styles.screenshotUrl} />
             </div>
             <div className={styles.screenshotBody}>
-              <img src="/img/tonkatsu_com.png" alt="Tonkatsu virtual office grid" className={styles.screenshotImg} />
+              <img src={useBaseUrl('/img/tonkatsu_com.png')} alt="Tonkatsu virtual office grid" className={styles.screenshotImg} />
             </div>
           </div>
         </div>
@@ -150,7 +151,7 @@ function HowItWorks() {
           </div>
           <div className={styles.showcaseScreenshot}>
             <video
-              src="/img/tonkatsu_animation.mov"
+              src={useBaseUrl('/img/tonkatsu_animation.mov')}
               autoPlay
               loop
               muted
@@ -199,7 +200,7 @@ function Screenshot() {
             </div>
           </div>
           <div className={styles.showcaseScreenshot}>
-            <img src="/img/tonkatsu_home.png" alt="Tonkatsu agent chat in action" className={styles.showcaseImg} />
+            <img src={useBaseUrl('/img/tonkatsu_home.png')} alt="Tonkatsu agent chat in action" className={styles.showcaseImg} />
           </div>
         </div>
       </div>
@@ -211,7 +212,7 @@ function CTA() {
   return (
     <section className={styles.ctaSection}>
       <div className={styles.ctaInner}>
-        <img src="/img/tonkatsu.png" alt="" className={styles.ctaLogo} aria-hidden />
+        <img src={useBaseUrl('/img/tonkatsu.png')} alt="" className={styles.ctaLogo} aria-hidden />
         <h2 className={styles.ctaTitle}>Ready to build your AI team?</h2>
         <p className={styles.ctaSub}>Open-source. Self-hosted. Your API key never leaves your server.</p>
         <div className={styles.heroCtas}>


### PR DESCRIPTION
## Problem

Images and videos don't render on GitHub Pages because they use absolute paths (`/img/...`) that don't account for the `baseUrl: '/data-platform-tonkatsu/'` prefix.

The browser requests `/img/tonkatsu.png` instead of `/data-platform-tonkatsu/img/tonkatsu.png`.

## Fix

**`docs/src/pages/index.tsx`** — added `import useBaseUrl from '@docusaurus/useBaseUrl'` and replaced all 5 hardcoded `src="/img/..."` attributes:
- `<img src="/img/tonkatsu.png">` → `src={useBaseUrl('/img/tonkatsu.png')}`
- `<img src="/img/tonkatsu_com.png">` → `src={useBaseUrl('/img/tonkatsu_com.png')}`
- `<img src="/img/tonkatsu_home.png">` → `src={useBaseUrl('/img/tonkatsu_home.png')}`
- `<video src="/img/tonkatsu_animation.mov">` → `src={useBaseUrl('/img/tonkatsu_animation.mov')}`

**`docs/docs/intro.md`** — replaced inline JSX image:
- `src="/img/tonkatsu.png"` → `src={require("@site/static/img/tonkatsu.png").default}`

🤖 Generated with [Claude Code](https://claude.ai/claude-code)