### PR TITLE
docs: remove Built with Docusaurus from footer

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -62,7 +62,7 @@ const config: Config = {
     },
     footer: {
       style: 'dark',
-      copyright: `Copyright © ${new Date().getFullYear()} Tonkatsu. Built with Docusaurus.`,
+      copyright: `Copyright © ${new Date().getFullYear()} Tonkatsu.`,
     },
     colorMode: {
       defaultMode: 'dark',


### PR DESCRIPTION
## Summary
- Removes the "Built with Docusaurus." sentence from the site footer copyright string in `docs/docusaurus.config.ts`

## Test plan
- [ ] Build docs and verify footer shows `Copyright © 2026 Tonkatsu.` without the Docusaurus attribution

🤖 Generated with [Claude Code](https://claude.com/claude-code)