### PR TITLE
feat: add Dockerfile and CI/CD setup

### DIFF
--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,6 +2,8 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
 import { PORT, READ_ONLY } from './config.js';
 import { createAgentRouter, createRoomsRouter, createTeamsRouter } from './routes/agents.js';
 import { createWorkspacesRouter } from './routes/workspaces.js';
@@ -60,6 +62,15 @@ app.use('/api/schedules', createSchedulesRouter(io));
 app.use('/api/skills', createSkillsRouter());
 app.use('/api/ssh-keys', createSshKeysRouter());
 app.use('/api/workspace-sync', createWorkspaceSyncRouter(io));
+
+// ── Serve React client (production) ─────────────────────────────────────────
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const clientDist = join(__dirname, '../../client/dist');
+app.use(express.static(clientDist));
+app.get('*', (_req, res) => {
+  res.sendFile(join(clientDist, 'index.html'));
+});
 
 // ── Load data before accepting connections ───────────────────────────────────
 


### PR DESCRIPTION
## Summary

- Add multi-stage `Dockerfile` (`node:20-alpine`): builder compiles client (Vite) and server (tsc), runtime stage installs only server prod deps and serves React static files from Express on port 3001
- Add `.dockerignore` (excludes `node_modules`, `dist`, `.env`, `repos`, `workspaces`, `.git`)
- Add `express.static` + SPA fallback to `server/src/index.ts` so Express serves the built React client in production

**Bug fixes discovered during build:**
- `client/src/components/ChatModal.tsx`: `agent?.name` — TypeScript doesn't narrow `const` through closures
- `server/src/routes/templates.ts`: `agent.workspacePath` instead of `agent.repoUrl` — wrong field passed to `snapshotWorkspace()` (real logic bug, not just a type error)

## Test plan

- [ ] `docker build -t data-platform-tonkatsu:local .` — should complete with no errors
- [ ] `docker run -p 3001:3001 -e ANTHROPIC_API_KEY=... data-platform-tonkatsu:local` — server starts on port 3001
- [ ] `http://localhost:3001` serves the React UI
- [ ] `http://localhost:3001/api/config` returns JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)