### PR TITLE
docs: update docs to use Docker image

### DIFF
--- a/docs/docs/deployment.md
+++ b/docs/docs/deployment.md
@@ -6,9 +6,11 @@ sidebar_position: 8
 
 # Deployment
 
-Running Tonkatsu in production requires building both packages, configuring the server environment, and optionally setting up a reverse proxy and process manager.
+Tonkatsu can be deployed as a **Docker image** (recommended) or by running the compiled Node.js output directly with a process manager. Both approaches are covered below.
 
-## Build
+## Build (Node.js / non-Docker)
+
+Skip this section if you're using Docker — the `Dockerfile` handles the build internally.
 
 ```bash
 npm run build
@@ -225,30 +227,62 @@ caddy run --config Caddyfile
 
 ---
 
-## Persistent storage
+## Docker
 
-The `workspaces/` and `repos/` directories must persist across deployments. Do not store them in ephemeral locations (e.g., a Docker container's filesystem without a volume mount).
+The repository includes a production-ready multi-stage `Dockerfile`. The builder stage compiles the client (Vite) and server (tsc), then the runtime stage copies only the production artefacts into a slim `node:20-alpine` image.
 
-**If using Docker:**
+### Build
 
-```dockerfile
-FROM node:20-alpine
-WORKDIR /app
-COPY . .
-RUN npm install && npm run build
-
-VOLUME ["/app/workspaces", "/app/repos", "/app/.sync-data"]
-
-EXPOSE 3001
-CMD ["node", "server/dist/index.js"]
+```bash
+docker build -t tonkatsu .
 ```
+
+### Run
 
 ```bash
 docker run -d \
+  --name tonkatsu \
   -p 3001:3001 \
   -v $(pwd)/workspaces:/app/workspaces \
   -v $(pwd)/repos:/app/repos \
-  -v $(pwd)/.sync-data:/app/.sync-data \
+  --env-file server/.env \
+  tonkatsu
+```
+
+The server serves the API, Socket.IO, and the compiled client at `http://localhost:3001`.
+
+### docker-compose
+
+```yaml
+# docker-compose.yml
+services:
+  tonkatsu:
+    build: .
+    ports:
+      - "3001:3001"
+    volumes:
+      - ./workspaces:/app/workspaces
+      - ./repos:/app/repos
+    env_file:
+      - server/.env
+    restart: unless-stopped
+```
+
+```bash
+docker compose up -d
+```
+
+### Persistent storage
+
+The `workspaces/` and `repos/` directories must persist across container restarts and image updates. Always bind-mount or use named volumes for these paths — never rely on the container's ephemeral filesystem.
+
+```bash
+# Named volumes (alternative to bind mounts)
+docker run -d \
+  --name tonkatsu \
+  -p 3001:3001 \
+  -v tonkatsu_workspaces:/app/workspaces \
+  -v tonkatsu_repos:/app/repos \
   --env-file server/.env \
   tonkatsu
 ```
@@ -256,6 +290,28 @@ docker run -d \
 ---
 
 ## Upgrading
+
+**Docker:**
+
+```bash
+git pull
+docker build -t tonkatsu .
+docker stop tonkatsu && docker rm tonkatsu
+docker run -d --name tonkatsu -p 3001:3001 \
+  -v $(pwd)/workspaces:/app/workspaces \
+  -v $(pwd)/repos:/app/repos \
+  --env-file server/.env \
+  tonkatsu
+```
+
+Or with docker-compose:
+
+```bash
+git pull
+docker compose build && docker compose up -d
+```
+
+**Node.js / PM2:**
 
 ```bash
 git pull

--- a/docs/docs/getting-started.md
+++ b/docs/docs/getting-started.md
@@ -10,19 +10,31 @@ This guide walks you through installing Tonkatsu, creating your first AI assista
 
 ## What you need before starting
 
-- **Node.js 18 or later** — the runtime that powers the server ([download here](https://nodejs.org))
 - **An Anthropic API key** — this is what lets assistants think. Get one at [console.anthropic.com](https://console.anthropic.com/)
+- **Docker** *(recommended)* — zero-dependency install. Or use Node.js 18+ if you prefer running from source.
 - **Git** — only needed if you want assistants that work inside a code repository
 
-## Step 1 — Download and install
+## Step 1 — Install
+
+### Option A — Docker (recommended)
+
+No Node.js required on the host. The image bundles everything.
 
 ```bash
-git clone https://github.com/pierredosne/my-team.git
-cd my-team
-npm install
+git clone https://github.com/pierredosne-fin/data-platform-tonkatsu.git
+cd data-platform-tonkatsu
+
+# Build the image
+docker build -t tonkatsu .
 ```
 
-`npm install` downloads all required software packages for both the app and the server automatically.
+### Option B — Node.js
+
+```bash
+git clone https://github.com/pierredosne-fin/data-platform-tonkatsu.git
+cd data-platform-tonkatsu
+npm install
+```
 
 ## Step 2 — Add your API key
 
@@ -37,6 +49,22 @@ This file is never shared or committed to version control. The API key stays on 
 
 ## Step 3 — Start the app
 
+### Option A — Docker
+
+```bash
+docker run -d \
+  --name tonkatsu \
+  -p 3001:3001 \
+  -v $(pwd)/workspaces:/app/workspaces \
+  -v $(pwd)/repos:/app/repos \
+  --env-file server/.env \
+  tonkatsu
+```
+
+The UI is served by the same container at [http://localhost:3001](http://localhost:3001).
+
+### Option B — Node.js (dev mode)
+
 ```bash
 npm run dev
 ```
@@ -48,7 +76,7 @@ This starts two things at once:
 | The office UI | http://localhost:5173 | The browser interface you'll use every day |
 | The server | http://localhost:3001 | Handles AI, data, and real-time updates |
 
-Open [http://localhost:5173](http://localhost:5173) in your browser. You'll see an empty grid — your office, ready for assistants.
+Open [http://localhost:5173](http://localhost:5173) in your browser (or [http://localhost:3001](http://localhost:3001) if using Docker). You'll see an empty grid — your office, ready for assistants.
 
 ## Step 4 — Create your first assistant
 


### PR DESCRIPTION
## Summary
- **Getting started**: Docker is now the recommended install path (Option A) with a `docker build` + `docker run` flow; Node.js dev mode is Option B
- **Deployment**: replaces the old inline `Dockerfile` snippet with the repo's actual multi-stage `Dockerfile`; adds a `docker-compose.yml` example, a named-volume variant, and Docker-aware upgrade steps

## Test plan
- [ ] Build docs and verify Getting Started shows Docker as Option A
- [ ] Verify Deployment page Docker section matches the actual `Dockerfile` in the repo
- [ ] Confirm docker-compose example is syntactically correct

🤖 Generated with [Claude Code](https://claude.com/claude-code)