### PR TITLE
fix: update baseUrl and docs for tonkatsu-ai repo

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -8,7 +8,7 @@ const config: Config = {
   favicon: 'img/tonkatsu.png',
 
   url: 'https://pierredosne-fin.github.io',
-  baseUrl: '/data-platform-tonkatsu/',
+  baseUrl: '/tonkatsu-ai/',
 
   onBrokenLinks: 'throw',
   markdown: {


### PR DESCRIPTION
## Summary
- **fix**: update `baseUrl` in `docs/docusaurus.config.ts` from `/data-platform-tonkatsu/` to `/tonkatsu-ai/` — fixes GitHub Pages rendering after repo rename
- **docs**: update Getting Started and Deployment pages to use the Docker image (multi-stage `Dockerfile`) as the recommended install and deployment path; add `docker-compose` example and Docker-aware upgrade steps
- **docs**: remove "Built with Docusaurus." from footer copyright

## Test plan
- [ ] Verify GitHub Pages renders correctly at https://pierredosne-fin.github.io/tonkatsu-ai/
- [ ] Check Getting Started shows Docker as Option A
- [ ] Check Deployment page Docker section matches the actual `Dockerfile`

🤖 Generated with [Claude Code](https://claude.com/claude-code)