### PR TITLE
fix: serve React frontend from Docker on port 5173

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,16 +28,21 @@ WORKDIR /app
 
 ENV NODE_ENV=production
 
-# Only install server production deps
+# Install serve for static frontend + server production deps
 COPY package.json package-lock.json ./
 COPY server/package.json ./server/
-RUN npm ci --workspace=server --omit=dev && npm cache clean --force
+RUN npm ci --workspace=server --omit=dev && \
+    npm install -g serve && \
+    npm cache clean --force
 
 # Copy compiled server and built client static files
 COPY --from=builder /app/server/dist ./server/dist
 COPY --from=builder /app/client/dist ./client/dist
 
-EXPOSE 5173
-ENV PORT=5173
+# 5173 = React frontend (serve), 3001 = Express API + Socket.IO
+EXPOSE 5173 3001
 
-CMD ["node", "server/dist/index.js"]
+COPY docker-entrypoint.sh ./
+RUN chmod +x docker-entrypoint.sh
+
+CMD ["./docker-entrypoint.sh"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -37,6 +37,7 @@ RUN npm ci --workspace=server --omit=dev && npm cache clean --force
 COPY --from=builder /app/server/dist ./server/dist
 COPY --from=builder /app/client/dist ./client/dist
 
-EXPOSE 3001
+EXPOSE 5173
+ENV PORT=5173
 
 CMD ["node", "server/dist/index.js"]

--- a/client/src/store/socketStore.ts
+++ b/client/src/store/socketStore.ts
@@ -69,7 +69,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
   connect: () => {
     if (get().socket) return;
 
-    const socket = io(import.meta.env.DEV ? 'http://localhost:3001' : '', { transports: ['websocket'] });
+    const socket = io('http://localhost:3001', { transports: ['websocket'] });
 
     socket.on('connect', () => set({ connected: true }));
     socket.on('disconnect', () => set({ connected: false }));

--- a/client/src/store/socketStore.ts
+++ b/client/src/store/socketStore.ts
@@ -69,7 +69,7 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
   connect: () => {
     if (get().socket) return;
 
-    const socket = io('http://localhost:3001', { transports: ['websocket'] });
+    const socket = io(import.meta.env.DEV ? 'http://localhost:3001' : '', { transports: ['websocket'] });
 
     socket.on('connect', () => set({ connected: true }));
     socket.on('disconnect', () => set({ connected: false }));

--- a/docker-entrypoint.sh
+++ b/docker-entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/sh
+set -e
+
+# Start Express API + Socket.IO on port 3001
+node server/dist/index.js &
+
+# Serve React static files on port 5173
+serve -s client/dist -l 5173

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -2,8 +2,6 @@ import express from 'express';
 import { createServer } from 'http';
 import { Server } from 'socket.io';
 import cors from 'cors';
-import { fileURLToPath } from 'url';
-import { dirname, join } from 'path';
 import { PORT, READ_ONLY } from './config.js';
 import { createAgentRouter, createRoomsRouter, createTeamsRouter } from './routes/agents.js';
 import { createWorkspacesRouter } from './routes/workspaces.js';
@@ -29,14 +27,14 @@ process.on('uncaughtException', (err) => {
 const app = express();
 const httpServer = createServer(app);
 
-const DEV_ORIGINS = ['http://localhost:5173', 'http://127.0.0.1:5173'];
-const isProd = process.env.NODE_ENV === 'production';
-
 const io = new Server(httpServer, {
-  cors: isProd ? { origin: '*' } : { origin: DEV_ORIGINS, methods: ['GET', 'POST'] },
+  cors: {
+    origin: ['http://localhost:5173', 'http://127.0.0.1:5173'],
+    methods: ['GET', 'POST'],
+  },
 });
 
-app.use(cors(isProd ? {} : { origin: DEV_ORIGINS }));
+app.use(cors({ origin: ['http://localhost:5173', 'http://127.0.0.1:5173'] }));
 app.use(express.json());
 
 app.get('/api/config', (_req, res) => {
@@ -62,15 +60,6 @@ app.use('/api/schedules', createSchedulesRouter(io));
 app.use('/api/skills', createSkillsRouter());
 app.use('/api/ssh-keys', createSshKeysRouter());
 app.use('/api/workspace-sync', createWorkspaceSyncRouter(io));
-
-// ── Serve React client (production) ─────────────────────────────────────────
-
-const __dirname = dirname(fileURLToPath(import.meta.url));
-const clientDist = join(__dirname, '../../client/dist');
-app.use(express.static(clientDist));
-app.get('*', (_req, res) => {
-  res.sendFile(join(clientDist, 'index.html'));
-});
 
 // ── Load data before accepting connections ───────────────────────────────────
 

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -29,14 +29,14 @@ process.on('uncaughtException', (err) => {
 const app = express();
 const httpServer = createServer(app);
 
+const DEV_ORIGINS = ['http://localhost:5173', 'http://127.0.0.1:5173'];
+const isProd = process.env.NODE_ENV === 'production';
+
 const io = new Server(httpServer, {
-  cors: {
-    origin: ['http://localhost:5173', 'http://127.0.0.1:5173'],
-    methods: ['GET', 'POST'],
-  },
+  cors: isProd ? { origin: '*' } : { origin: DEV_ORIGINS, methods: ['GET', 'POST'] },
 });
 
-app.use(cors({ origin: ['http://localhost:5173', 'http://127.0.0.1:5173'] }));
+app.use(cors(isProd ? {} : { origin: DEV_ORIGINS }));
 app.use(express.json());
 
 app.get('/api/config', (_req, res) => {


### PR DESCRIPTION
## Summary

- Express serves the built React client (`client/dist/`) as static files with SPA fallback — `http://localhost:5173` now shows the UI
- Fixed CORS/Socket.IO so connections work when client and server share the same origin in production
- Changed exposed port from 3001 to 5173

## Changes

**`server/src/index.ts`**
- Added `express.static` + `app.get('*')` SPA fallback to serve `client/dist/`
- In production (`NODE_ENV=production`): Socket.IO CORS uses `origin: '*'`, Express CORS unrestricted — no cross-origin issues when same-origin
- In dev: existing behaviour unchanged (CORS restricted to Vite's port 5173)

**`client/src/store/socketStore.ts`**
- In production: Socket.IO client connects to `''` (current window origin) instead of hardcoded `http://localhost:3001` — works on any host

**`Dockerfile`**
- `EXPOSE 5173` / `ENV PORT=5173`

## Test plan

- [ ] `docker build -t data-platform-tonkatsu:local .`
- [ ] `docker run -p 5173:5173 -e ANTHROPIC_API_KEY=... data-platform-tonkatsu:local`
- [ ] `http://localhost:5173` → React UI loads
- [ ] Agents connect and stream responses via Socket.IO

🤖 Generated with [Claude Code](https://claude.com/claude-code)