### PR TITLE
fix: install git and openssh-client in Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,6 +29,8 @@ WORKDIR /app
 ENV NODE_ENV=production
 ENV PORT=5173
 
+RUN apk add --no-cache git openssh-client
+
 # Only install server production deps
 COPY package.json package-lock.json ./
 COPY server/package.json ./server/


### PR DESCRIPTION
## Summary

- `node:20-alpine` runtime stage was missing `git` and `openssh-client`
- SSH key operations use `GIT_SSH_COMMAND=ssh -i ...` which requires the `ssh` binary at runtime
- Added `RUN apk add --no-cache git openssh-client` to the runtime stage

## Test plan

- [ ] Build the Docker image and verify `git` and `ssh` are available
- [ ] Upload an SSH key via the UI and confirm git clone/sync works inside the container

🤖 Generated with [Claude Code](https://claude.com/claude-code)