### PR TITLE
feat: add gh, gcloud, and bq to Docker runtime image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -22,14 +22,27 @@ RUN npm run build -w client && npm run build -w server
 # ──────────────────────────────────────────────
 # Stage 2: Runtime — production image
 # ──────────────────────────────────────────────
-FROM node:20-alpine AS runtime
+FROM node:20-slim AS runtime
 
 WORKDIR /app
 
 ENV NODE_ENV=production
 ENV PORT=5173
 
-RUN apk add --no-cache git openssh-client
+# Base tools + GitHub CLI + Google Cloud SDK (includes gcloud and bq)
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git openssh-client curl ca-certificates gnupg \
+    && curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg \
+         | dd of=/usr/share/keyrings/githubcli-archive-keyring.gpg \
+    && echo "deb [arch=$(dpkg --print-architecture) signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" \
+         > /etc/apt/sources.list.d/github-cli.list \
+    && curl -fsSL https://packages.cloud.google.com/apt/doc/apt-key.gpg \
+         | gpg --dearmor -o /usr/share/keyrings/cloud.google.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/cloud.google.gpg] https://packages.cloud.google.com/apt cloud-sdk main" \
+         > /etc/apt/sources.list.d/google-cloud-sdk.list \
+    && apt-get update && apt-get install -y --no-install-recommends \
+         gh google-cloud-cli \
+    && rm -rf /var/lib/apt/lists/*
 
 # Only install server production deps
 COPY package.json package-lock.json ./


### PR DESCRIPTION
## Summary
- Switch runtime base image from `node:20-alpine` to `node:20-slim` (Debian) — required for Google Cloud SDK which has no Alpine package
- Install `gh` (GitHub CLI) via official GitHub apt repo
- Install `google-cloud-cli` (includes `gcloud` + `bq`) via official Google apt repo

## Test plan
- [ ] Build Docker image locally: `docker build -t test .`
- [ ] Verify tools: `docker run --rm test gh --version`, `docker run --rm test gcloud --version`, `docker run --rm test bq version`

🤖 Generated with [Claude Code](https://claude.com/claude-code)