### PR TITLE
feat: auto-install global SSH key as ~/.ssh/id_rsa for agent git/gh access

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -42,7 +42,10 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
          > /etc/apt/sources.list.d/google-cloud-sdk.list \
     && apt-get update && apt-get install -y --no-install-recommends \
          gh google-cloud-cli \
-    && rm -rf /var/lib/apt/lists/*
+    && rm -rf /var/lib/apt/lists/* \
+    && mkdir -p /root/.ssh \
+    && ssh-keyscan github.com >> /root/.ssh/known_hosts 2>/dev/null \
+    && chmod 700 /root/.ssh
 
 # Only install server production deps
 COPY package.json package-lock.json ./

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -13,7 +13,7 @@ import { createSkillsRouter } from './routes/skills.js';
 import { createSshKeysRouter } from './routes/sshKeys.js';
 import { createWorkspaceSyncRouter } from './routes/workspaceSync.js';
 import { registerHandlers } from './socket/handlers.js';
-import { loadAllAgents } from './services/persistenceService.js';
+import { loadAllAgents, setupSshIdentity } from './services/persistenceService.js';
 import { restoreAgent } from './services/agentService.js';
 import { loadAllTemplates, syncTemplateFolders } from './services/templateService.js';
 import { loadAllSkills } from './services/skillService.js';
@@ -77,6 +77,7 @@ if (isProd) {
 
 // ── Load data before accepting connections ───────────────────────────────────
 
+try { setupSshIdentity(); } catch (err) { console.error('[startup] setupSshIdentity failed:', err); }
 try { loadAllTemplates(); } catch (err) { console.error('[startup] loadAllTemplates failed:', err); }
 try { syncTemplateFolders(); } catch (err) { console.error('[startup] syncTemplateFolders failed:', err); }
 try { loadAllSkills(); } catch (err) { console.error('[startup] loadAllSkills failed:', err); }

--- a/server/src/services/persistenceService.ts
+++ b/server/src/services/persistenceService.ts
@@ -246,21 +246,31 @@ export function getSshKeyPath(name: string): string {
 }
 
 /**
- * Install the global SSH key as ~/.ssh/id_rsa so that git and gh CLI
- * commands run by agents work without needing GIT_SSH_COMMAND.
+ * Install the global SSH key as ~/.ssh/id_rsa and configure gh CLI to use
+ * SSH as git protocol, so that both git and gh commands work without tokens.
  * No-op if the global key is not configured.
  */
 export function setupSshIdentity(): void {
   const keyPath = getSshKeyPath(GLOBAL_SSH_KEY_NAME);
   if (!existsSync(keyPath)) return;
   try {
+    // ~/.ssh/id_rsa
     const sshDir = join(homedir(), '.ssh');
     mkdirSync(sshDir, { recursive: true });
     try { chmodSync(sshDir, 0o700); } catch { /* ignore */ }
     const idRsa = join(sshDir, 'id_rsa');
     writeFileSync(idRsa, readFileSync(keyPath, 'utf-8'), 'utf-8');
     try { chmodSync(idRsa, 0o600); } catch { /* ignore */ }
-    console.log('[ssh] Global SSH key installed to ~/.ssh/id_rsa');
+
+    // ~/.config/gh/hosts.yml — tell gh to use SSH so no token is needed
+    const ghConfigDir = join(homedir(), '.config', 'gh');
+    mkdirSync(ghConfigDir, { recursive: true });
+    const hostsyml = join(ghConfigDir, 'hosts.yml');
+    if (!existsSync(hostsyml)) {
+      writeFileSync(hostsyml, 'github.com:\n    git_protocol: ssh\n    users: {}\n', 'utf-8');
+    }
+
+    console.log('[ssh] Global SSH key installed to ~/.ssh/id_rsa, gh configured for SSH');
   } catch (err) {
     console.warn('[ssh] Failed to install SSH identity:', err);
   }

--- a/server/src/services/persistenceService.ts
+++ b/server/src/services/persistenceService.ts
@@ -1,5 +1,6 @@
 import { readFileSync, writeFileSync, readdirSync, existsSync, mkdirSync, chmodSync, unlinkSync } from 'fs';
 import { join, dirname, basename, isAbsolute, relative } from 'path';
+import { homedir } from 'os';
 import { fileURLToPath } from 'url';
 import type { Agent, AgentTemplate, TeamTemplate, CronSchedule, SkillTemplate, GitSync } from '../models/types.js';
 
@@ -226,15 +227,43 @@ export function saveSshKey(name: string, content: string): void {
   const keyPath = join(SSH_KEYS_DIR, name);
   writeFileSync(keyPath, content, 'utf-8');
   try { chmodSync(keyPath, 0o600); } catch { /* ignore on windows */ }
+  if (name === GLOBAL_SSH_KEY_NAME) setupSshIdentity();
 }
 
 export function deleteSshKey(name: string): void {
   const keyPath = join(SSH_KEYS_DIR, name);
   if (existsSync(keyPath)) unlinkSync(keyPath);
+  if (name === GLOBAL_SSH_KEY_NAME) {
+    try {
+      const idRsa = join(homedir(), '.ssh', 'id_rsa');
+      if (existsSync(idRsa)) unlinkSync(idRsa);
+    } catch { /* ignore */ }
+  }
 }
 
 export function getSshKeyPath(name: string): string {
   return join(SSH_KEYS_DIR, name);
+}
+
+/**
+ * Install the global SSH key as ~/.ssh/id_rsa so that git and gh CLI
+ * commands run by agents work without needing GIT_SSH_COMMAND.
+ * No-op if the global key is not configured.
+ */
+export function setupSshIdentity(): void {
+  const keyPath = getSshKeyPath(GLOBAL_SSH_KEY_NAME);
+  if (!existsSync(keyPath)) return;
+  try {
+    const sshDir = join(homedir(), '.ssh');
+    mkdirSync(sshDir, { recursive: true });
+    try { chmodSync(sshDir, 0o700); } catch { /* ignore */ }
+    const idRsa = join(sshDir, 'id_rsa');
+    writeFileSync(idRsa, readFileSync(keyPath, 'utf-8'), 'utf-8');
+    try { chmodSync(idRsa, 0o600); } catch { /* ignore */ }
+    console.log('[ssh] Global SSH key installed to ~/.ssh/id_rsa');
+  } catch (err) {
+    console.warn('[ssh] Failed to install SSH identity:', err);
+  }
 }
 
 export function loadAllAgents(): PersistedAgent[] {


### PR DESCRIPTION
## Summary
- When the global SSH key is saved via the UI/API, it is now automatically copied to `~/.ssh/id_rsa` so agents can run `git` and `gh` commands natively without any extra env setup
- On server startup, the same setup runs — so the key survives container restarts
- Deleting the key via the API also removes `~/.ssh/id_rsa`
- Dockerfile: GitHub's host keys are pre-added to `/root/.ssh/known_hosts` at build time — no SSH host verification prompt

## How `gh` authentication works
| Operation | Auth mechanism |
|---|---|
| `git push/pull/clone` (SSH) | `~/.ssh/id_rsa` (this PR) |
| `gh pr create`, `gh issue`, etc. | `GITHUB_TOKEN` env var (pass `-e GITHUB_TOKEN=...` to Docker) |

## Test plan
- [ ] Upload an SSH key via the UI → verify `~/.ssh/id_rsa` exists in container (`docker exec ... cat ~/.ssh/id_rsa`)
- [ ] Agent runs `git clone git@github.com:...` → succeeds without prompts
- [ ] Agent runs `gh pr list` with `GITHUB_TOKEN` set → succeeds
- [ ] Delete SSH key via UI → verify `~/.ssh/id_rsa` is removed
- [ ] Restart container with key pre-configured → verify key is restored on startup

🤖 Generated with [Claude Code](https://claude.com/claude-code)