### PR TITLE
feat: pixel snow animation on docs home page

### DIFF
--- a/docs/src/pages/index.module.css
+++ b/docs/src/pages/index.module.css
@@ -32,6 +32,16 @@
   border-bottom: 1px solid var(--ifm-color-emphasis-300);
 }
 
+.pixelSnow {
+  position: absolute;
+  inset: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
+  z-index: 0;
+  image-rendering: pixelated;
+}
+
 /* subtle radial glow */
 .hero::before {
   content: '';
@@ -59,6 +69,7 @@
   padding: 5rem 2rem 0;
   text-align: center;
   position: relative;
+  z-index: 1;
 }
 
 .heroLogo {

--- a/docs/src/pages/index.tsx
+++ b/docs/src/pages/index.tsx
@@ -1,13 +1,87 @@
-import React from 'react';
+import React, { useEffect, useRef } from 'react';
 import Link from '@docusaurus/Link';
 import useDocusaurusContext from '@docusaurus/useDocusaurusContext';
 import useBaseUrl from '@docusaurus/useBaseUrl';
 import Layout from '@theme/Layout';
 import styles from './index.module.css';
 
+function PixelSnow() {
+  const canvasRef = useRef<HTMLCanvasElement>(null);
+
+  useEffect(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    let animId: number;
+    const PIXEL = 3;
+    const COUNT = 120;
+
+    type Flake = { x: number; y: number; speed: number; drift: number; opacity: number; size: number };
+
+    const resize = () => {
+      canvas.width = canvas.offsetWidth;
+      canvas.height = canvas.offsetHeight;
+    };
+    resize();
+    window.addEventListener('resize', resize);
+
+    const isDark = () => document.documentElement.getAttribute('data-theme') === 'dark';
+
+    const flakes: Flake[] = Array.from({ length: COUNT }, () => ({
+      x: Math.random() * canvas.width,
+      y: Math.random() * canvas.height,
+      speed: 0.3 + Math.random() * 0.7,
+      drift: (Math.random() - 0.5) * 0.4,
+      opacity: 0.15 + Math.random() * 0.45,
+      size: PIXEL * (0.5 + Math.random()),
+    }));
+
+    const draw = () => {
+      ctx.clearRect(0, 0, canvas.width, canvas.height);
+      const dark = isDark();
+
+      for (const f of flakes) {
+        ctx.globalAlpha = f.opacity;
+        ctx.fillStyle = dark ? '#c4b5fd' : '#7c3aed';
+        ctx.fillRect(
+          Math.round(f.x / PIXEL) * PIXEL,
+          Math.round(f.y / PIXEL) * PIXEL,
+          Math.ceil(f.size),
+          Math.ceil(f.size),
+        );
+
+        f.y += f.speed;
+        f.x += f.drift;
+
+        if (f.y > canvas.height + 4) {
+          f.y = -4;
+          f.x = Math.random() * canvas.width;
+        }
+        if (f.x < -4) f.x = canvas.width + 4;
+        if (f.x > canvas.width + 4) f.x = -4;
+      }
+
+      ctx.globalAlpha = 1;
+      animId = requestAnimationFrame(draw);
+    };
+
+    draw();
+
+    return () => {
+      cancelAnimationFrame(animId);
+      window.removeEventListener('resize', resize);
+    };
+  }, []);
+
+  return <canvas ref={canvasRef} className={styles.pixelSnow} aria-hidden />;
+}
+
 function Hero() {
   return (
     <section className={styles.hero}>
+      <PixelSnow />
       <div className={styles.heroInner}>
         <img src={useBaseUrl('/img/tonkatsu.png')} alt="Tonkatsu" className={styles.heroLogo} />
         <h1 className={styles.heroTitle}>


### PR DESCRIPTION
## Summary

- Adds a `PixelSnow` canvas component to the hero section of the docs landing page
- 120 small pixel squares fall slowly with gentle horizontal drift, snapped to a pixel grid
- Color adapts to theme: purple (`#7c3aed`) in light mode, lavender (`#c4b5fd`) in dark mode
- Non-interactive (`pointer-events: none`, `aria-hidden`), auto-resizes on window resize

## Test plan

- [ ] Run `npm run dev:all` and open the docs at localhost:5173/docs (or the docs port)
- [ ] Verify snow animation appears in the hero background in both light and dark mode
- [ ] Resize the window — canvas should fill the hero correctly
- [ ] Confirm no layout shift or content obstruction (hero text/buttons remain on top)

🤖 Generated with [Claude Code](https://claude.com/claude-code)