### PR TITLE
feat: SOUL.md / OPS.md / TOOLS.md editable from the UI

### DIFF
--- a/client/src/components/CreateAgentModal.tsx
+++ b/client/src/components/CreateAgentModal.tsx
@@ -22,6 +22,9 @@ interface EditAgent {
 
 interface WorkspaceFiles {
   claudeMd: string | null;
+  soul: string | null;
+  ops: string | null;
+  tools: string | null;
   settings: string | null;
   commands: { name: string; content: string }[];
   rules: { name: string; content: string }[];
@@ -37,7 +40,7 @@ interface Props {
   editAgent?: EditAgent;
 }
 
-type Tab = 'basic' | 'claude-md' | 'commands' | 'rules' | 'skills' | 'settings';
+type Tab = 'basic' | 'claude-md' | 'soul-md' | 'ops-md' | 'tools-md' | 'commands' | 'rules' | 'skills' | 'settings';
 
 export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamId, editAgent }: Props) {
   const agentTemplates = useTemplateStore((s) => s.agentTemplates);
@@ -69,6 +72,9 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
   // Per-file editing state
   const [claudeMd, setClaudeMd] = useState('');
   const [generatingClaudeMd, setGeneratingClaudeMd] = useState(false);
+  const [soulMd, setSoulMd] = useState('');
+  const [opsMd, setOpsMd] = useState('');
+  const [toolsMd, setToolsMd] = useState('');
   const [settingsJson, setSettingsJson] = useState('');
   const [editingFile, setEditingFile] = useState<{ type: 'command' | 'rule' | 'skill'; name: string; content: string } | null>(null);
   const [newFileName, setNewFileName] = useState('');
@@ -85,6 +91,9 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
       .then((data: WorkspaceFiles) => {
         setFiles(data);
         setClaudeMd(data.claudeMd ?? '');
+        setSoulMd(data.soul ?? '');
+        setOpsMd(data.ops ?? '');
+        setToolsMd(data.tools ?? '');
         setSettingsJson(data.settings ?? '{\n  "mcpServers": {}\n}');
       })
       .finally(() => setFilesLoading(false));
@@ -161,6 +170,27 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
     if (!res.ok) setFileError('Failed to save CLAUDE.md');
   };
 
+  const saveSoulMd = async () => {
+    setSavingFile(true); setFileError('');
+    const res = await fetch(`/api/agents/${editAgent!.id}/files/soul-md`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: soulMd }) });
+    setSavingFile(false);
+    if (!res.ok) setFileError('Failed to save SOUL.md');
+  };
+
+  const saveOpsMd = async () => {
+    setSavingFile(true); setFileError('');
+    const res = await fetch(`/api/agents/${editAgent!.id}/files/ops-md`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: opsMd }) });
+    setSavingFile(false);
+    if (!res.ok) setFileError('Failed to save OPS.md');
+  };
+
+  const saveToolsMd = async () => {
+    setSavingFile(true); setFileError('');
+    const res = await fetch(`/api/agents/${editAgent!.id}/files/tools-md`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: toolsMd }) });
+    setSavingFile(false);
+    if (!res.ok) setFileError('Failed to save TOOLS.md');
+  };
+
   const saveSettings = async () => {
     setSavingFile(true);
     setFileError('');
@@ -214,6 +244,9 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
   const TABS: { id: Tab; label: string }[] = [
     { id: 'basic', label: 'Basic' },
     { id: 'claude-md', label: 'CLAUDE.md' },
+    { id: 'soul-md', label: 'SOUL.md' },
+    { id: 'ops-md', label: 'OPS.md' },
+    { id: 'tools-md', label: 'TOOLS.md' },
     { id: 'commands', label: 'Commands' },
     { id: 'rules', label: 'Rules' },
     { id: 'skills', label: 'Skills' },
@@ -389,6 +422,66 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
                   <button type="button" className="btn btn-primary" onClick={saveClaudeMd} disabled={savingFile}>
                     {savingFile ? 'Saving…' : 'Save CLAUDE.md'}
                   </button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* ── SOUL.md Tab ── */}
+        {tab === 'soul-md' && (
+          <div className="modal-body modal-body--file">
+            {filesLoading ? <div className="file-loading">Loading…</div> : (
+              <>
+                <div className="file-editor-header">
+                  <span className="file-editor-title">SOUL.md</span>
+                  <span className="form-hint">Identity, principles, and core values</span>
+                </div>
+                <textarea className="file-editor" value={soulMd} onChange={(e) => setSoulMd(e.target.value)} placeholder="# Soul&#10;&#10;Core identity and principles…" spellCheck={false} />
+                {fileError && <div className="file-error">{fileError}</div>}
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-ghost" onClick={onClose}>Close</button>
+                  <button type="button" className="btn btn-primary" onClick={saveSoulMd} disabled={savingFile}>{savingFile ? 'Saving…' : 'Save SOUL.md'}</button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* ── OPS.md Tab ── */}
+        {tab === 'ops-md' && (
+          <div className="modal-body modal-body--file">
+            {filesLoading ? <div className="file-loading">Loading…</div> : (
+              <>
+                <div className="file-editor-header">
+                  <span className="file-editor-title">OPS.md</span>
+                  <span className="form-hint">Operational playbook, recurring tasks, constraints</span>
+                </div>
+                <textarea className="file-editor" value={opsMd} onChange={(e) => setOpsMd(e.target.value)} placeholder="# Operational Playbook&#10;&#10;Recurring tasks and conventions…" spellCheck={false} />
+                {fileError && <div className="file-error">{fileError}</div>}
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-ghost" onClick={onClose}>Close</button>
+                  <button type="button" className="btn btn-primary" onClick={saveOpsMd} disabled={savingFile}>{savingFile ? 'Saving…' : 'Save OPS.md'}</button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {/* ── TOOLS.md Tab ── */}
+        {tab === 'tools-md' && (
+          <div className="modal-body modal-body--file">
+            {filesLoading ? <div className="file-loading">Loading…</div> : (
+              <>
+                <div className="file-editor-header">
+                  <span className="file-editor-title">TOOLS.md</span>
+                  <span className="form-hint">Available tools, API endpoints, environment</span>
+                </div>
+                <textarea className="file-editor" value={toolsMd} onChange={(e) => setToolsMd(e.target.value)} placeholder="# Tools &amp; Environment&#10;&#10;Available tools and endpoints…" spellCheck={false} />
+                {fileError && <div className="file-error">{fileError}</div>}
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-ghost" onClick={onClose}>Close</button>
+                  <button type="button" className="btn btn-primary" onClick={saveToolsMd} disabled={savingFile}>{savingFile ? 'Saving…' : 'Save TOOLS.md'}</button>
                 </div>
               </>
             )}

--- a/client/src/components/CreateAgentModal.tsx
+++ b/client/src/components/CreateAgentModal.tsx
@@ -75,6 +75,9 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
   const [soulMd, setSoulMd] = useState('');
   const [opsMd, setOpsMd] = useState('');
   const [toolsMd, setToolsMd] = useState('');
+  const [generatingSoul, setGeneratingSoul] = useState(false);
+  const [generatingOps, setGeneratingOps] = useState(false);
+  const [generatingTools, setGeneratingTools] = useState(false);
   const [settingsJson, setSettingsJson] = useState('');
   const [editingFile, setEditingFile] = useState<{ type: 'command' | 'rule' | 'skill'; name: string; content: string } | null>(null);
   const [newFileName, setNewFileName] = useState('');
@@ -168,6 +171,16 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
     });
     setSavingFile(false);
     if (!res.ok) setFileError('Failed to save CLAUDE.md');
+  };
+
+  const generateWorkspaceFile = async (file: 'soul' | 'ops' | 'tools', current: string, set: (v: string) => void, setGenerating: (v: boolean) => void) => {
+    setGenerating(true); setFileError('');
+    const res = await fetch(`/api/agents/${editAgent!.id}/generate-workspace-file`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, current }),
+    });
+    setGenerating(false);
+    if (res.ok) { const { content } = await res.json(); set(content); }
+    else setFileError('Generation failed');
   };
 
   const saveSoulMd = async () => {
@@ -435,7 +448,9 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
               <>
                 <div className="file-editor-header">
                   <span className="file-editor-title">SOUL.md</span>
-                  <span className="form-hint">Identity, principles, and core values</span>
+                  <button type="button" className="btn btn-ghost btn-sm" onClick={() => generateWorkspaceFile('soul', soulMd, setSoulMd, setGeneratingSoul)} disabled={generatingSoul}>
+                    {generatingSoul ? 'Generating…' : soulMd.trim() ? '✦ Improve' : '✦ Generate'}
+                  </button>
                 </div>
                 <textarea className="file-editor" value={soulMd} onChange={(e) => setSoulMd(e.target.value)} placeholder="# Soul&#10;&#10;Core identity and principles…" spellCheck={false} />
                 {fileError && <div className="file-error">{fileError}</div>}
@@ -455,7 +470,9 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
               <>
                 <div className="file-editor-header">
                   <span className="file-editor-title">OPS.md</span>
-                  <span className="form-hint">Operational playbook, recurring tasks, constraints</span>
+                  <button type="button" className="btn btn-ghost btn-sm" onClick={() => generateWorkspaceFile('ops', opsMd, setOpsMd, setGeneratingOps)} disabled={generatingOps}>
+                    {generatingOps ? 'Generating…' : opsMd.trim() ? '✦ Improve' : '✦ Generate'}
+                  </button>
                 </div>
                 <textarea className="file-editor" value={opsMd} onChange={(e) => setOpsMd(e.target.value)} placeholder="# Operational Playbook&#10;&#10;Recurring tasks and conventions…" spellCheck={false} />
                 {fileError && <div className="file-error">{fileError}</div>}
@@ -475,7 +492,9 @@ export function CreateAgentModal({ onClose, onCreate, onEdit, initialName, teamI
               <>
                 <div className="file-editor-header">
                   <span className="file-editor-title">TOOLS.md</span>
-                  <span className="form-hint">Available tools, API endpoints, environment</span>
+                  <button type="button" className="btn btn-ghost btn-sm" onClick={() => generateWorkspaceFile('tools', toolsMd, setToolsMd, setGeneratingTools)} disabled={generatingTools}>
+                    {generatingTools ? 'Generating…' : toolsMd.trim() ? '✦ Improve' : '✦ Generate'}
+                  </button>
                 </div>
                 <textarea className="file-editor" value={toolsMd} onChange={(e) => setToolsMd(e.target.value)} placeholder="# Tools &amp; Environment&#10;&#10;Available tools and endpoints…" spellCheck={false} />
                 {fileError && <div className="file-error">{fileError}</div>}

--- a/client/src/components/CreateAgentTemplateModal.tsx
+++ b/client/src/components/CreateAgentTemplateModal.tsx
@@ -14,6 +14,9 @@ const PRESET_COLORS = [
 
 interface WorkspaceFiles {
   claudeMd: string | null;
+  soul: string | null;
+  ops: string | null;
+  tools: string | null;
   settings: string | null;
   commands: { name: string; content: string }[];
   rules: { name: string; content: string }[];
@@ -26,7 +29,7 @@ interface Props {
   editTemplate?: AgentTemplate;
 }
 
-type Tab = 'basic' | 'claude-md' | 'commands' | 'rules' | 'skills' | 'settings';
+type Tab = 'basic' | 'claude-md' | 'soul-md' | 'ops-md' | 'tools-md' | 'commands' | 'rules' | 'skills' | 'settings';
 
 export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: Props) {
   const createAgentTemplate = useTemplateStore((s) => s.createAgentTemplate);
@@ -45,6 +48,9 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
   const [filesLoading, setFilesLoading] = useState(false);
   const [claudeMd, setClaudeMd] = useState('');
   const [generatingClaudeMd, setGeneratingClaudeMd] = useState(false);
+  const [soulMd, setSoulMd] = useState('');
+  const [opsMd, setOpsMd] = useState('');
+  const [toolsMd, setToolsMd] = useState('');
   const [settingsJson, setSettingsJson] = useState('');
   const [editingFile, setEditingFile] = useState<{ type: 'command' | 'rule' | 'skill'; name: string; content: string } | null>(null);
   const [newFileName, setNewFileName] = useState('');
@@ -62,6 +68,9 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
       .then((data: WorkspaceFiles) => {
         setFiles(data);
         setClaudeMd(data.claudeMd ?? '');
+        setSoulMd(data.soul ?? '');
+        setOpsMd(data.ops ?? '');
+        setToolsMd(data.tools ?? '');
         setSettingsJson(data.settings ?? '{\n  "mcpServers": {}\n}');
       })
       .finally(() => setFilesLoading(false));
@@ -123,6 +132,27 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
     if (!res.ok) setFileError('Failed to save CLAUDE.md');
   };
 
+  const saveSoulMd = async () => {
+    setSavingFile(true); setFileError('');
+    const res = await fetch(`${baseUrl}/files/soul-md`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: soulMd }) });
+    setSavingFile(false);
+    if (!res.ok) setFileError('Failed to save SOUL.md');
+  };
+
+  const saveOpsMd = async () => {
+    setSavingFile(true); setFileError('');
+    const res = await fetch(`${baseUrl}/files/ops-md`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: opsMd }) });
+    setSavingFile(false);
+    if (!res.ok) setFileError('Failed to save OPS.md');
+  };
+
+  const saveToolsMd = async () => {
+    setSavingFile(true); setFileError('');
+    const res = await fetch(`${baseUrl}/files/tools-md`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: toolsMd }) });
+    setSavingFile(false);
+    if (!res.ok) setFileError('Failed to save TOOLS.md');
+  };
+
   const saveSettings = async () => {
     setSavingFile(true); setFileError('');
     const res = await fetch(`${baseUrl}/files/settings`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: settingsJson }) });
@@ -168,6 +198,9 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
   const TABS: { id: Tab; label: string }[] = [
     { id: 'basic', label: 'Basic' },
     { id: 'claude-md', label: 'CLAUDE.md' },
+    { id: 'soul-md', label: 'SOUL.md' },
+    { id: 'ops-md', label: 'OPS.md' },
+    { id: 'tools-md', label: 'TOOLS.md' },
     { id: 'commands', label: 'Commands' },
     { id: 'rules', label: 'Rules' },
     { id: 'skills', label: 'Skills' },
@@ -308,6 +341,63 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
                 <div className="modal-footer">
                   <button type="button" className="btn btn-ghost" onClick={onClose}>Close</button>
                   <button type="button" className="btn btn-primary" onClick={saveClaudeMd} disabled={savingFile}>{savingFile ? 'Saving…' : 'Save CLAUDE.md'}</button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {tab === 'soul-md' && (
+          <div className="modal-body modal-body--file">
+            {filesLoading ? <div className="file-loading">Loading…</div> : (
+              <>
+                <div className="file-editor-header">
+                  <span className="file-editor-title">SOUL.md</span>
+                  <span className="form-hint">Identity, principles, and core values</span>
+                </div>
+                <textarea className="file-editor" value={soulMd} onChange={(e) => setSoulMd(e.target.value)} placeholder="# Soul&#10;&#10;Core identity and principles…" spellCheck={false} />
+                {fileError && <div className="file-error">{fileError}</div>}
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-ghost" onClick={onClose}>Close</button>
+                  <button type="button" className="btn btn-primary" onClick={saveSoulMd} disabled={savingFile}>{savingFile ? 'Saving…' : 'Save SOUL.md'}</button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {tab === 'ops-md' && (
+          <div className="modal-body modal-body--file">
+            {filesLoading ? <div className="file-loading">Loading…</div> : (
+              <>
+                <div className="file-editor-header">
+                  <span className="file-editor-title">OPS.md</span>
+                  <span className="form-hint">Operational playbook, recurring tasks, constraints</span>
+                </div>
+                <textarea className="file-editor" value={opsMd} onChange={(e) => setOpsMd(e.target.value)} placeholder="# Operational Playbook&#10;&#10;Recurring tasks and conventions…" spellCheck={false} />
+                {fileError && <div className="file-error">{fileError}</div>}
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-ghost" onClick={onClose}>Close</button>
+                  <button type="button" className="btn btn-primary" onClick={saveOpsMd} disabled={savingFile}>{savingFile ? 'Saving…' : 'Save OPS.md'}</button>
+                </div>
+              </>
+            )}
+          </div>
+        )}
+
+        {tab === 'tools-md' && (
+          <div className="modal-body modal-body--file">
+            {filesLoading ? <div className="file-loading">Loading…</div> : (
+              <>
+                <div className="file-editor-header">
+                  <span className="file-editor-title">TOOLS.md</span>
+                  <span className="form-hint">Available tools, API endpoints, environment</span>
+                </div>
+                <textarea className="file-editor" value={toolsMd} onChange={(e) => setToolsMd(e.target.value)} placeholder="# Tools &amp; Environment&#10;&#10;Available tools and endpoints…" spellCheck={false} />
+                {fileError && <div className="file-error">{fileError}</div>}
+                <div className="modal-footer">
+                  <button type="button" className="btn btn-ghost" onClick={onClose}>Close</button>
+                  <button type="button" className="btn btn-primary" onClick={saveToolsMd} disabled={savingFile}>{savingFile ? 'Saving…' : 'Save TOOLS.md'}</button>
                 </div>
               </>
             )}

--- a/client/src/components/CreateAgentTemplateModal.tsx
+++ b/client/src/components/CreateAgentTemplateModal.tsx
@@ -51,6 +51,9 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
   const [soulMd, setSoulMd] = useState('');
   const [opsMd, setOpsMd] = useState('');
   const [toolsMd, setToolsMd] = useState('');
+  const [generatingSoul, setGeneratingSoul] = useState(false);
+  const [generatingOps, setGeneratingOps] = useState(false);
+  const [generatingTools, setGeneratingTools] = useState(false);
   const [settingsJson, setSettingsJson] = useState('');
   const [editingFile, setEditingFile] = useState<{ type: 'command' | 'rule' | 'skill'; name: string; content: string } | null>(null);
   const [newFileName, setNewFileName] = useState('');
@@ -130,6 +133,17 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
     const res = await fetch(`${baseUrl}/files/claude-md`, { method: 'PUT', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ content: claudeMd }) });
     setSavingFile(false);
     if (!res.ok) setFileError('Failed to save CLAUDE.md');
+  };
+
+  const generateWorkspaceFile = async (file: 'soul' | 'ops' | 'tools', current: string, set: (v: string) => void, setGenerating: (v: boolean) => void) => {
+    if (!isEdit) return;
+    setGenerating(true); setFileError('');
+    const res = await fetch(`/api/templates/agents/${editTemplate!.id}/generate-workspace-file`, {
+      method: 'POST', headers: { 'Content-Type': 'application/json' }, body: JSON.stringify({ file, current }),
+    });
+    setGenerating(false);
+    if (res.ok) { const { content } = await res.json(); set(content); }
+    else setFileError('Generation failed');
   };
 
   const saveSoulMd = async () => {
@@ -353,7 +367,9 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
               <>
                 <div className="file-editor-header">
                   <span className="file-editor-title">SOUL.md</span>
-                  <span className="form-hint">Identity, principles, and core values</span>
+                  <button type="button" className="btn btn-ghost btn-sm" onClick={() => generateWorkspaceFile('soul', soulMd, setSoulMd, setGeneratingSoul)} disabled={generatingSoul}>
+                    {generatingSoul ? 'Generating…' : soulMd.trim() ? '✦ Improve' : '✦ Generate'}
+                  </button>
                 </div>
                 <textarea className="file-editor" value={soulMd} onChange={(e) => setSoulMd(e.target.value)} placeholder="# Soul&#10;&#10;Core identity and principles…" spellCheck={false} />
                 {fileError && <div className="file-error">{fileError}</div>}
@@ -372,7 +388,9 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
               <>
                 <div className="file-editor-header">
                   <span className="file-editor-title">OPS.md</span>
-                  <span className="form-hint">Operational playbook, recurring tasks, constraints</span>
+                  <button type="button" className="btn btn-ghost btn-sm" onClick={() => generateWorkspaceFile('ops', opsMd, setOpsMd, setGeneratingOps)} disabled={generatingOps}>
+                    {generatingOps ? 'Generating…' : opsMd.trim() ? '✦ Improve' : '✦ Generate'}
+                  </button>
                 </div>
                 <textarea className="file-editor" value={opsMd} onChange={(e) => setOpsMd(e.target.value)} placeholder="# Operational Playbook&#10;&#10;Recurring tasks and conventions…" spellCheck={false} />
                 {fileError && <div className="file-error">{fileError}</div>}
@@ -391,7 +409,9 @@ export function CreateAgentTemplateModal({ onClose, onCreated, editTemplate }: P
               <>
                 <div className="file-editor-header">
                   <span className="file-editor-title">TOOLS.md</span>
-                  <span className="form-hint">Available tools, API endpoints, environment</span>
+                  <button type="button" className="btn btn-ghost btn-sm" onClick={() => generateWorkspaceFile('tools', toolsMd, setToolsMd, setGeneratingTools)} disabled={generatingTools}>
+                    {generatingTools ? 'Generating…' : toolsMd.trim() ? '✦ Improve' : '✦ Generate'}
+                  </button>
                 </div>
                 <textarea className="file-editor" value={toolsMd} onChange={(e) => setToolsMd(e.target.value)} placeholder="# Tools &amp; Environment&#10;&#10;Available tools and endpoints…" spellCheck={false} />
                 {fileError && <div className="file-error">{fileError}</div>}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -369,6 +369,47 @@ Write tailored, concise instructions that will make this agent highly effective 
     }
   });
 
+  router.post('/:id/generate-workspace-file', async (req, res) => {
+    const agent = agentService.getAgent(req.params.id);
+    if (!agent) { res.status(404).json({ error: 'Agent not found' }); return; }
+    const { file, current } = req.body;
+    if (!['soul', 'ops', 'tools'].includes(file)) { res.status(400).json({ error: 'file must be soul | ops | tools' }); return; }
+    const prompts: Record<string, { system: string; generate: string; improve: string }> = {
+      soul: {
+        system: `You are an expert at writing SOUL.md files for AI agents. SOUL.md defines the agent's identity, core principles, and values. It answers "who is this agent?" — not what it does, but how it thinks, what it stands for, and its working philosophy. Be concise, specific, and inspiring. Return ONLY the SOUL.md content, no preamble, no markdown code fences.`,
+        generate: `Write a SOUL.md for an agent named "${agent.name}".\n\nMission: ${agent.mission}\n\nDefine its identity, core principles, and values in a way that will guide all its decisions.`,
+        improve: `Improve this SOUL.md for an agent named "${agent.name}" with mission: "${agent.mission}".\n\nCurrent SOUL.md:\n${current}\n\nMake it more specific, principled, and actionable. Keep what's good.`,
+      },
+      ops: {
+        system: `You are an expert at writing OPS.md files for AI agents. OPS.md is the operational playbook — recurring tasks, conventions, constraints, and workflows the agent must follow. It answers "how does this agent operate day-to-day?". Be concrete and specific. Return ONLY the OPS.md content, no preamble, no markdown code fences.`,
+        generate: `Write an OPS.md for an agent named "${agent.name}".\n\nMission: ${agent.mission}\n\nDefine its recurring tasks, key conventions, constraints, and operational workflows.`,
+        improve: `Improve this OPS.md for an agent named "${agent.name}" with mission: "${agent.mission}".\n\nCurrent OPS.md:\n${current}\n\nMake it more actionable and complete. Keep what's good.`,
+      },
+      tools: {
+        system: `You are an expert at writing TOOLS.md files for AI agents. TOOLS.md documents the tools, APIs, endpoints, and environment context available to the agent. It answers "what can this agent use and where?". Be precise and useful. Return ONLY the TOOLS.md content, no preamble, no markdown code fences.`,
+        generate: `Write a TOOLS.md for an agent named "${agent.name}".\n\nMission: ${agent.mission}\n\nDocument the tools, APIs, and environment context this agent would typically have access to for its role.`,
+        improve: `Improve this TOOLS.md for an agent named "${agent.name}" with mission: "${agent.mission}".\n\nCurrent TOOLS.md:\n${current}\n\nMake it more complete and precise. Keep what's good.`,
+      },
+    };
+    const p = prompts[file as string];
+    const isImproving = typeof current === 'string' && current.trim().length > 0;
+    try {
+      const client = new Anthropic();
+      const message = await client.messages.create({
+        model: 'claude-opus-4-6',
+        max_tokens: 2048,
+        system: p.system,
+        messages: [{ role: 'user', content: isImproving ? p.improve : p.generate }],
+      });
+      const block = message.content[0];
+      if (block.type !== 'text') throw new Error('Unexpected response');
+      res.json({ content: block.text });
+    } catch (err) {
+      console.error('[agents] generate-workspace-file error:', err);
+      res.status(500).json({ error: 'Generation failed' });
+    }
+  });
+
   router.post('/:id/sync', (req, res) => {
     const agent = agentService.getAgent(req.params.id);
     if (!agent) { res.status(404).json({ error: 'Agent not found' }); return; }

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -179,6 +179,33 @@ export function createAgentRouter(io: Server) {
     }
   });
 
+  router.put('/:id/files/soul-md', (req, res) => {
+    const agent = agentService.getAgent(req.params.id);
+    if (!agent) { res.status(404).json({ error: 'Agent not found' }); return; }
+    const { content } = req.body;
+    if (typeof content !== 'string') { res.status(400).json({ error: 'content required' }); return; }
+    fileService.writeSoul(agent.workspacePath, content);
+    res.json({ ok: true });
+  });
+
+  router.put('/:id/files/ops-md', (req, res) => {
+    const agent = agentService.getAgent(req.params.id);
+    if (!agent) { res.status(404).json({ error: 'Agent not found' }); return; }
+    const { content } = req.body;
+    if (typeof content !== 'string') { res.status(400).json({ error: 'content required' }); return; }
+    fileService.writeOps(agent.workspacePath, content);
+    res.json({ ok: true });
+  });
+
+  router.put('/:id/files/tools-md', (req, res) => {
+    const agent = agentService.getAgent(req.params.id);
+    if (!agent) { res.status(404).json({ error: 'Agent not found' }); return; }
+    const { content } = req.body;
+    if (typeof content !== 'string') { res.status(400).json({ error: 'content required' }); return; }
+    fileService.writeTools(agent.workspacePath, content);
+    res.json({ ok: true });
+  });
+
   // ── Permissions ────────────────────────────────────────────────────────────
 
   router.get('/:id/permissions', (req, res) => {

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -80,6 +80,30 @@ export function createTemplatesRouter(io: Server) {
     catch { res.status(400).json({ error: 'Invalid JSON' }); }
   });
 
+  router.put('/agents/:id/files/soul-md', (req, res) => {
+    if (!templateService.getAgentTemplate(req.params.id)) { res.status(404).json({ error: 'Not found' }); return; }
+    const { content } = req.body;
+    if (typeof content !== 'string') { res.status(400).json({ error: 'content required' }); return; }
+    fileService.writeSoul(templateService.getAgentTemplateWorkspacePath(req.params.id), content);
+    res.json({ ok: true });
+  });
+
+  router.put('/agents/:id/files/ops-md', (req, res) => {
+    if (!templateService.getAgentTemplate(req.params.id)) { res.status(404).json({ error: 'Not found' }); return; }
+    const { content } = req.body;
+    if (typeof content !== 'string') { res.status(400).json({ error: 'content required' }); return; }
+    fileService.writeOps(templateService.getAgentTemplateWorkspacePath(req.params.id), content);
+    res.json({ ok: true });
+  });
+
+  router.put('/agents/:id/files/tools-md', (req, res) => {
+    if (!templateService.getAgentTemplate(req.params.id)) { res.status(404).json({ error: 'Not found' }); return; }
+    const { content } = req.body;
+    if (typeof content !== 'string') { res.status(400).json({ error: 'content required' }); return; }
+    fileService.writeTools(templateService.getAgentTemplateWorkspacePath(req.params.id), content);
+    res.json({ ok: true });
+  });
+
   router.put('/agents/:id/files/commands/:name(*)', (req, res) => {
     if (!templateService.getAgentTemplate(req.params.id)) { res.status(404).json({ error: 'Not found' }); return; }
     const { content } = req.body;

--- a/server/src/routes/templates.ts
+++ b/server/src/routes/templates.ts
@@ -195,6 +195,47 @@ Write tailored, concise instructions that will make this agent highly effective 
     }
   });
 
+  router.post('/agents/:id/generate-workspace-file', async (req, res) => {
+    const t = templateService.getAgentTemplate(req.params.id);
+    if (!t) { res.status(404).json({ error: 'Not found' }); return; }
+    const { file, current } = req.body;
+    if (!['soul', 'ops', 'tools'].includes(file)) { res.status(400).json({ error: 'file must be soul | ops | tools' }); return; }
+    const prompts: Record<string, { system: string; generate: string; improve: string }> = {
+      soul: {
+        system: `You are an expert at writing SOUL.md files for AI agents. SOUL.md defines the agent's identity, core principles, and values. It answers "who is this agent?" — not what it does, but how it thinks, what it stands for, and its working philosophy. Be concise, specific, and inspiring. Return ONLY the SOUL.md content, no preamble, no markdown code fences.`,
+        generate: `Write a SOUL.md for an agent template named "${t.name}".\n\nMission: ${t.mission}\n\nDefine its identity, core principles, and values in a way that will guide all its decisions.`,
+        improve: `Improve this SOUL.md for an agent template named "${t.name}" with mission: "${t.mission}".\n\nCurrent SOUL.md:\n${current}\n\nMake it more specific, principled, and actionable. Keep what's good.`,
+      },
+      ops: {
+        system: `You are an expert at writing OPS.md files for AI agents. OPS.md is the operational playbook — recurring tasks, conventions, constraints, and workflows the agent must follow. It answers "how does this agent operate day-to-day?". Be concrete and specific. Return ONLY the OPS.md content, no preamble, no markdown code fences.`,
+        generate: `Write an OPS.md for an agent template named "${t.name}".\n\nMission: ${t.mission}\n\nDefine its recurring tasks, key conventions, constraints, and operational workflows.`,
+        improve: `Improve this OPS.md for an agent template named "${t.name}" with mission: "${t.mission}".\n\nCurrent OPS.md:\n${current}\n\nMake it more actionable and complete. Keep what's good.`,
+      },
+      tools: {
+        system: `You are an expert at writing TOOLS.md files for AI agents. TOOLS.md documents the tools, APIs, endpoints, and environment context available to the agent. It answers "what can this agent use and where?". Be precise and useful. Return ONLY the TOOLS.md content, no preamble, no markdown code fences.`,
+        generate: `Write a TOOLS.md for an agent template named "${t.name}".\n\nMission: ${t.mission}\n\nDocument the tools, APIs, and environment context this agent would typically have access to for its role.`,
+        improve: `Improve this TOOLS.md for an agent template named "${t.name}" with mission: "${t.mission}".\n\nCurrent TOOLS.md:\n${current}\n\nMake it more complete and precise. Keep what's good.`,
+      },
+    };
+    const p = prompts[file as string];
+    const isImproving = typeof current === 'string' && current.trim().length > 0;
+    try {
+      const client = new Anthropic();
+      const message = await client.messages.create({
+        model: 'claude-opus-4-6',
+        max_tokens: 2048,
+        system: p.system,
+        messages: [{ role: 'user', content: isImproving ? p.improve : p.generate }],
+      });
+      const block = message.content[0];
+      if (block.type !== 'text') throw new Error('Unexpected response');
+      res.json({ content: block.text });
+    } catch (err) {
+      console.error('[templates] generate-workspace-file error:', err);
+      res.status(500).json({ error: 'Generation failed' });
+    }
+  });
+
   // ── Snapshot agent as template ──────────────────────────────────────────────
 
   router.post('/agents/from-agent/:agentId', (req, res) => {

--- a/server/src/services/fileService.ts
+++ b/server/src/services/fileService.ts
@@ -44,6 +44,9 @@ function listSkills(dir: string): { name: string; content: string }[] {
 
 export interface WorkspaceFiles {
   claudeMd: string | null;
+  soul: string | null;
+  ops: string | null;
+  tools: string | null;
   settings: string | null;
   commands: { name: string; content: string }[];
   rules: { name: string; content: string }[];
@@ -53,6 +56,9 @@ export interface WorkspaceFiles {
 export function readWorkspaceFiles(workspacePath: string): WorkspaceFiles {
   return {
     claudeMd: safeRead(join(workspacePath, 'CLAUDE.md')),
+    soul: safeRead(join(workspacePath, 'SOUL.md')),
+    ops: safeRead(join(workspacePath, 'OPS.md')),
+    tools: safeRead(join(workspacePath, 'TOOLS.md')),
     settings: safeRead(join(workspacePath, '.claude', 'settings.json')),
     commands: listMdFiles(join(workspacePath, '.claude', 'commands')),
     rules: listMdFiles(join(workspacePath, '.claude', 'rules')),
@@ -62,6 +68,18 @@ export function readWorkspaceFiles(workspacePath: string): WorkspaceFiles {
 
 export function writeClaudeMd(workspacePath: string, content: string): void {
   safeWrite(join(workspacePath, 'CLAUDE.md'), content);
+}
+
+export function writeSoul(workspacePath: string, content: string): void {
+  safeWrite(join(workspacePath, 'SOUL.md'), content);
+}
+
+export function writeOps(workspacePath: string, content: string): void {
+  safeWrite(join(workspacePath, 'OPS.md'), content);
+}
+
+export function writeTools(workspacePath: string, content: string): void {
+  safeWrite(join(workspacePath, 'TOOLS.md'), content);
 }
 
 export function writeSettings(workspacePath: string, content: string): void {
@@ -186,13 +204,13 @@ function copyDir(srcDir: string, destDir: string): void {
   }
 }
 
-/** Copy template workspace files (CLAUDE.md + .claude/) to an agent workspace, replacing .claude/ entirely. */
+/** Copy template workspace files (CLAUDE.md + SOUL.md + OPS.md + TOOLS.md + .claude/) to an agent workspace, replacing .claude/ entirely. */
 export function copyWorkspaceFiles(srcPath: string, destPath: string): void {
   if (!existsSync(srcPath)) return;
-  const claudeMd = join(srcPath, 'CLAUDE.md');
-  if (existsSync(claudeMd)) {
-    mkdirSync(destPath, { recursive: true });
-    copyFileSync(claudeMd, join(destPath, 'CLAUDE.md'));
+  mkdirSync(destPath, { recursive: true });
+  for (const file of ['CLAUDE.md', 'SOUL.md', 'OPS.md', 'TOOLS.md']) {
+    const src = join(srcPath, file);
+    if (existsSync(src)) copyFileSync(src, join(destPath, file));
   }
   const claudeDir = join(srcPath, '.claude');
   if (existsSync(claudeDir)) {
@@ -205,10 +223,10 @@ export function copyWorkspaceFiles(srcPath: string, destPath: string): void {
 
 /** Copy an agent's workspace files into a template directory, overwriting everything. */
 export function snapshotWorkspace(agentPath: string, templatePath: string): void {
-  const claudeMd = join(agentPath, 'CLAUDE.md');
-  if (existsSync(claudeMd)) {
-    mkdirSync(templatePath, { recursive: true });
-    copyFileSync(claudeMd, join(templatePath, 'CLAUDE.md'));
+  mkdirSync(templatePath, { recursive: true });
+  for (const file of ['CLAUDE.md', 'SOUL.md', 'OPS.md', 'TOOLS.md']) {
+    const src = join(agentPath, file);
+    if (existsSync(src)) copyFileSync(src, join(templatePath, file));
   }
   const claudeDir = join(agentPath, '.claude');
   if (existsSync(claudeDir)) {

--- a/server/src/services/gitService.ts
+++ b/server/src/services/gitService.ts
@@ -46,11 +46,8 @@ export function createWorktree(repoPath: string, worktreePath: string, branch: s
         const excludePatterns = [
           '.mcp.json',
           '.claude/**',
-          'SOUL.md',
           'USER.md',
-          'OPS.md',
           'MEMORY.md',
-          'TOOLS.md',
           'memory/',
         ].join('\n') + '\n';
         const excludeFile = join(infoDir, 'exclude');


### PR DESCRIPTION
## Summary

- SOUL.md, OPS.md, TOOLS.md are now editable from the agent edit modal and template edit modal (new tabs between CLAUDE.md and Commands)
- Files are loaded/saved via new API endpoints: `PUT /api/agents/:id/files/soul-md|ops-md|tools-md` and the template equivalents
- Template instantiation and workspace snapshot now copy SOUL/OPS/TOOLS alongside CLAUDE.md
- Git sync: removed SOUL/OPS/TOOLS from the worktree exclude list — if the repo contains these files they will be synced in; USER.md and MEMORY.md remain excluded (runtime state)

## Test plan

- [ ] Edit a live agent → confirm SOUL.md, OPS.md, TOOLS.md tabs appear and save correctly
- [ ] Edit a template → same tabs, save correctly
- [ ] Instantiate a team from a template that has SOUL/OPS/TOOLS populated → verify files appear in the new agent workspace
- [ ] Snapshot an agent as a template → SOUL/OPS/TOOLS included in template directory

🤖 Generated with [Claude Code](https://claude.com/claude-code)