### PR TITLE
fix: initialize SOUL.md, OPS.md, TOOLS.md for new and existing templates

### DIFF
--- a/server/src/services/fileService.ts
+++ b/server/src/services/fileService.ts
@@ -234,6 +234,20 @@ export function snapshotWorkspace(agentPath: string, templatePath: string): void
   }
 }
 
+/** Initialize SOUL.md, OPS.md, TOOLS.md for a template workspace (only if absent). */
+export function setupTemplateFiles(workspacePath: string, name: string, mission: string): void {
+  mkdirSync(workspacePath, { recursive: true });
+  const files: Record<string, string> = {
+    'SOUL.md':  `# Soul\n\n**Name:** ${name}\n**Mission:** ${mission}\n\nCore principles and identity of this agent.\n`,
+    'OPS.md':   `# Operational Playbook\n\nRecurring tasks, conventions, constraints.\n`,
+    'TOOLS.md': `# Tools & Environment\n\nAvailable tools, API endpoints, credentials location.\n`,
+  };
+  for (const [filename, content] of Object.entries(files)) {
+    const p = join(workspacePath, filename);
+    if (!existsSync(p)) writeFileSync(p, content, 'utf-8');
+  }
+}
+
 export function setupWorkspaceStructure(workspacePath: string, agentName: string, mission: string): void {
   const today = new Date().toISOString().slice(0, 10);
 

--- a/server/src/services/templateService.ts
+++ b/server/src/services/templateService.ts
@@ -3,6 +3,7 @@ import { join } from 'path';
 import { rmSync, existsSync, readdirSync, mkdirSync } from 'fs';
 import type { AgentTemplate, TeamTemplate } from '../models/types.js';
 import { loadTemplates, saveTemplates, WORKSPACES_DIR } from './persistenceService.js';
+import { setupTemplateFiles } from './fileService.js';
 
 export function getAgentTemplateWorkspacePath(templateId: string): string {
   return join(WORKSPACES_DIR, 'templates', templateId);
@@ -59,7 +60,7 @@ export function createAgentTemplate(params: {
   };
   agentTemplates.push(template);
   persist();
-  mkdirSync(getAgentTemplateWorkspacePath(template.id), { recursive: true });
+  setupTemplateFiles(getAgentTemplateWorkspacePath(template.id), template.name, template.mission);
   return template;
 }
 
@@ -129,13 +130,12 @@ export function syncTemplateFolders(): void {
   const templatesDir = join(WORKSPACES_DIR, 'templates');
   mkdirSync(templatesDir, { recursive: true });
 
-  // 1. Create missing folders for templates that don't have one
+  // 1. Create missing folders and initialize SOUL/OPS/TOOLS for templates that don't have them
   for (const t of agentTemplates) {
     const dir = getAgentTemplateWorkspacePath(t.id);
-    if (!existsSync(dir)) {
-      mkdirSync(dir, { recursive: true });
-      console.log(`[templates] Created missing folder for: ${t.name}`);
-    }
+    const isNew = !existsSync(dir);
+    setupTemplateFiles(dir, t.name, t.mission);
+    if (isNew) console.log(`[templates] Created missing folder for: ${t.name}`);
   }
 
   // 2. Remove folders that have no corresponding template entry


### PR DESCRIPTION
## Summary

- Add `setupTemplateFiles()` in `fileService.ts` — creates SOUL.md, OPS.md, TOOLS.md (only if absent) in a template workspace
- Call it in `createAgentTemplate()` so new templates have these files from the start
- Call it in `syncTemplateFolders()` to backfill all existing templates on next server boot (idempotent — won't overwrite existing content)

## Test plan

- [ ] Create a new agent template → SOUL.md, OPS.md, TOOLS.md tabs show default content
- [ ] Restart server with existing templates → files are backfilled without overwriting customized ones
- [ ] Edit and save SOUL/OPS/TOOLS on an existing template → content persists correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)