### PR TITLE
feat: FAN_OUT parallel dispatch + templates/agents permission

### DIFF
--- a/server/src/services/fileService.ts
+++ b/server/src/services/fileService.ts
@@ -88,7 +88,10 @@ export function writeSettings(workspacePath: string, content: string): void {
   safeWrite(join(workspacePath, '.claude', 'settings.json'), content);
 }
 
-const CREATE_AGENTS_PERMISSION = 'Bash(curl -s -X POST http://localhost:3001/api/agents*)';
+const CREATE_AGENTS_PERMISSIONS = [
+  'Bash(curl -s -X POST http://localhost:3001/api/agents*)',
+  'Bash(curl -s http://localhost:3001/api/templates/agents*)',
+];
 
 
 export function setCreateAgentsPermission(workspacePath: string, enabled: boolean): void {
@@ -102,15 +105,16 @@ export function setCreateAgentsPermission(workspacePath: string, enabled: boolea
   }
 
   const perms = settings.permissions as Record<string, unknown> | undefined ?? {};
-  const allow = Array.isArray(perms.allow) ? [...perms.allow as string[]] : [];
+  let allow = Array.isArray(perms.allow) ? [...perms.allow as string[]] : [];
 
   if (enabled) {
-    if (!allow.includes(CREATE_AGENTS_PERMISSION)) {
-      allow.push(CREATE_AGENTS_PERMISSION);
+    for (const perm of CREATE_AGENTS_PERMISSIONS) {
+      if (!allow.includes(perm)) {
+        allow.push(perm);
+      }
     }
   } else {
-    const idx = allow.indexOf(CREATE_AGENTS_PERMISSION);
-    if (idx !== -1) allow.splice(idx, 1);
+    allow = allow.filter((p) => !CREATE_AGENTS_PERMISSIONS.includes(p));
   }
 
   settings.permissions = { ...perms, allow };


### PR DESCRIPTION
## Summary
- **FAN_OUT support**: agent responses containing `<FAN_OUT><TASK agent="...">` blocks now trigger parallel fire-and-forget task dispatch to multiple agents simultaneously
- **System prompt**: FAN_OUT syntax documented to agents alongside CALL_AGENT
- **canCreateAgents permission**: now also grants `GET /api/templates/agents*` so agents can list available templates before spawning new ones (closes #43)

## Changes
- `server/src/services/claudeService.ts`: add `FAN_OUT_RE`/`TASK_RE` regexes, `dispatchFanOut()` function, FAN_OUT check in `runAgentTask()`, FAN_OUT docs in system prompt
- `server/src/services/fileService.ts`: `CREATE_AGENTS_PERMISSION` → `CREATE_AGENTS_PERMISSIONS` array with POST + GET entries

## Test plan
- [ ] Restart server, send a task to an agent whose response contains a `<FAN_OUT>` block
- [ ] Verify all named agents start working concurrently (`status: working`)
- [ ] Verify caller agent returns to `sleeping` immediately (no waiting)
- [ ] Verify `canCreateAgents` agents have both POST and GET template permissions in settings.json

🤖 Generated with [Claude Code](https://claude.com/claude-code)