### PR TITLE
feat: authorization gates for zoom-in access control

### DIFF
--- a/server/src/middleware/rateLimit.ts
+++ b/server/src/middleware/rateLimit.ts
@@ -1,0 +1,66 @@
+import type { Request, Response, NextFunction } from 'express';
+
+interface Bucket {
+  count: number;
+  resetAt: number;
+}
+
+// Shared bucket store: key → { count, resetAt }
+const httpBuckets = new Map<string, Bucket>();
+const socketBuckets = new Map<string, Bucket>();
+
+const DEFAULT_WINDOW_MS = 60_000;
+const DEFAULT_MAX = 60;
+
+function getBucket(store: Map<string, Bucket>, key: string, windowMs: number): Bucket {
+  const now = Date.now();
+  let bucket = store.get(key);
+  if (!bucket || now >= bucket.resetAt) {
+    bucket = { count: 0, resetAt: now + windowMs };
+    store.set(key, bucket);
+  }
+  return bucket;
+}
+
+/** Express middleware: rate-limits by IP. Attaches X-RateLimit-* headers. */
+export function createRateLimiter(maxRequests = DEFAULT_MAX, windowMs = DEFAULT_WINDOW_MS) {
+  return function rateLimiter(req: Request, res: Response, next: NextFunction): void {
+    const key = req.ip ?? 'unknown';
+    const bucket = getBucket(httpBuckets, key, windowMs);
+    bucket.count++;
+
+    const remaining = Math.max(0, maxRequests - bucket.count);
+    const resetEpoch = Math.floor(bucket.resetAt / 1000);
+
+    res.setHeader('X-RateLimit-Limit', String(maxRequests));
+    res.setHeader('X-RateLimit-Remaining', String(remaining));
+    res.setHeader('X-RateLimit-Reset', String(resetEpoch));
+
+    if (bucket.count > maxRequests) {
+      const retryAfter = Math.ceil((bucket.resetAt - Date.now()) / 1000);
+      res.setHeader('Retry-After', String(retryAfter));
+      res.status(429).json({
+        error: 'Too many requests',
+        code: 'RATE_LIMIT_EXCEEDED',
+        retryAfter,
+      });
+      return;
+    }
+
+    next();
+  };
+}
+
+/**
+ * Check rate limit for a socket event. Returns true if allowed, false if exceeded.
+ * The caller is responsible for emitting the appropriate error.
+ */
+export function checkSocketRateLimit(
+  socketId: string,
+  maxRequests = 30,
+  windowMs = DEFAULT_WINDOW_MS,
+): boolean {
+  const bucket = getBucket(socketBuckets, socketId, windowMs);
+  bucket.count++;
+  return bucket.count <= maxRequests;
+}

--- a/server/src/middleware/zoom.ts
+++ b/server/src/middleware/zoom.ts
@@ -1,0 +1,116 @@
+/**
+ * Zoom-in access control middleware.
+ *
+ * Authorization model:
+ *  - `x-user-id` request header identifies the caller (defaults to "anonymous").
+ *  - `x-team-id` request header optionally scopes access to a single team.
+ *    When present, the target agent/room must belong to that team.
+ *  - All zoom attempts (allowed or denied) are written to the audit log.
+ *
+ * 403 body shape:
+ *  { error: string, code: "ZOOM_FORBIDDEN", resourceType: "agent"|"room", resourceId: string }
+ */
+
+import type { Request, Response, NextFunction } from 'express';
+import * as agentService from '../services/agentService.js';
+import * as roomService from '../services/roomService.js';
+import { writeAuditLog } from '../services/auditService.js';
+
+export interface ZoomForbiddenBody {
+  error: string;
+  code: 'ZOOM_FORBIDDEN';
+  resourceType: 'room' | 'agent';
+  resourceId: string;
+}
+
+function resolveUserId(req: Request): string {
+  return (req.headers['x-user-id'] as string | undefined) ?? 'anonymous';
+}
+
+function resolveTeamId(req: Request): string | undefined {
+  return req.headers['x-team-id'] as string | undefined;
+}
+
+/** Gate GET /api/agents/:id — validates team membership when x-team-id is set. */
+export function requireAgentZoomAccess(req: Request, res: Response, next: NextFunction): void {
+  const agentId = req.params.id;
+  const userId = resolveUserId(req);
+  const teamId = resolveTeamId(req);
+  const agent = agentService.getAgent(agentId);
+
+  const exists = !!agent;
+  const allowed = exists && (teamId === undefined || agent!.teamId === teamId);
+
+  writeAuditLog({
+    timestamp: new Date().toISOString(),
+    event: 'agent:zoom-in',
+    userId,
+    resourceType: 'agent',
+    resourceId: agentId,
+    teamId,
+    allowed,
+    ip: req.ip,
+  });
+
+  if (!exists) {
+    res.status(404).json({ error: 'Agent not found' });
+    return;
+  }
+
+  if (!allowed) {
+    const body: ZoomForbiddenBody = {
+      error: 'You do not have access to this agent',
+      code: 'ZOOM_FORBIDDEN',
+      resourceType: 'agent',
+      resourceId: agentId,
+    };
+    res.status(403).json(body);
+    return;
+  }
+
+  next();
+}
+
+/** Gate GET /api/rooms/:id — validates team membership when x-team-id is set. */
+export function requireRoomZoomAccess(req: Request, res: Response, next: NextFunction): void {
+  const roomId = req.params.id;
+  const userId = resolveUserId(req);
+  const teamId = resolveTeamId(req);
+  const room = roomService.getAllRooms().find((r) => r.id === roomId);
+
+  const exists = !!room;
+  let allowed = exists;
+  if (allowed && teamId !== undefined && room!.agentId) {
+    const occupant = agentService.getAgent(room!.agentId);
+    allowed = !occupant || occupant.teamId === teamId;
+  }
+
+  writeAuditLog({
+    timestamp: new Date().toISOString(),
+    event: 'room:zoom-in',
+    userId,
+    resourceType: 'room',
+    resourceId: roomId,
+    teamId,
+    allowed,
+    ip: req.ip,
+  });
+
+  if (!exists) {
+    res.status(404).json({ error: 'Room not found' });
+    return;
+  }
+
+  if (!allowed) {
+    const body: ZoomForbiddenBody = {
+      error: 'You do not have access to this room',
+      code: 'ZOOM_FORBIDDEN',
+      resourceType: 'room',
+      resourceId: roomId,
+    };
+    res.status(403).json(body);
+    return;
+  }
+
+  next();
+}

--- a/server/src/routes/agents.ts
+++ b/server/src/routes/agents.ts
@@ -7,8 +7,12 @@ import * as templateService from '../services/templateService.js';
 import { runAgentTask } from '../services/claudeService.js';
 import { deleteSchedulesForAgent } from '../services/cronService.js';
 import { syncAgentRepo, syncWorktreeFromBase } from '../services/gitService.js';
+import { createRateLimiter } from '../middleware/rateLimit.js';
+import { requireAgentZoomAccess, requireRoomZoomAccess } from '../middleware/zoom.js';
 import Anthropic from '@anthropic-ai/sdk';
 import type { Server } from 'socket.io';
+
+const zoomRateLimit = createRateLimiter(60, 60_000);
 
 export function createAgentRouter(io: Server) {
   const router = Router();
@@ -94,6 +98,14 @@ export function createAgentRouter(io: Server) {
       console.error('[agents] generate-mission error:', err);
       res.status(500).json({ error: 'Generation failed' });
     }
+  });
+
+  // ── Zoom-in detail endpoint ───────────────────────────────────────────────
+  // Rate-limited + access-gated. Emits audit log on every call.
+  router.get('/:id', zoomRateLimit, requireAgentZoomAccess, (req, res) => {
+    const agent = agentService.getAgent(req.params.id);
+    // requireAgentZoomAccess already verified existence, so agent is non-null here
+    res.json(agentService.toClientAgent(agent!));
   });
 
   router.post('/:id/trigger', (req, res) => {
@@ -447,8 +459,16 @@ export function createTeamsRouter(io: Server) {
 
 export function createRoomsRouter() {
   const router = Router();
+
   router.get('/', (_req, res) => {
     res.json(roomService.getAllRooms());
   });
+
+  // ── Zoom-in detail endpoint ───────────────────────────────────────────────
+  router.get('/:id', zoomRateLimit, requireRoomZoomAccess, (req, res) => {
+    const room = roomService.getAllRooms().find((r) => r.id === req.params.id);
+    res.json(room);
+  });
+
   return router;
 }

--- a/server/src/services/auditService.ts
+++ b/server/src/services/auditService.ts
@@ -1,0 +1,31 @@
+import { appendFileSync, mkdirSync } from 'fs';
+import { join } from 'path';
+
+const AUDIT_DIR = join(process.cwd(), 'workspaces', '.audit');
+
+try { mkdirSync(AUDIT_DIR, { recursive: true }); } catch { /* ignore */ }
+
+export interface AuditEntry {
+  timestamp: string;
+  event: 'room:zoom-in' | 'agent:zoom-in';
+  userId: string;
+  resourceType: 'room' | 'agent';
+  resourceId: string;
+  teamId?: string;
+  allowed: boolean;
+  ip?: string;
+}
+
+export function writeAuditLog(entry: AuditEntry): void {
+  const line = JSON.stringify(entry) + '\n';
+  const date = entry.timestamp.slice(0, 10);
+  const file = join(AUDIT_DIR, `${date}.jsonl`);
+  try {
+    appendFileSync(file, line, 'utf8');
+  } catch (err) {
+    console.error('[audit] failed to write log:', err);
+  }
+  console.log(
+    `[audit] ${entry.event} user=${entry.userId} ${entry.resourceType}=${entry.resourceId} allowed=${entry.allowed}`,
+  );
+}

--- a/server/src/socket/handlers.ts
+++ b/server/src/socket/handlers.ts
@@ -1,7 +1,23 @@
 import type { Server, Socket } from 'socket.io';
 import * as agentService from '../services/agentService.js';
+import * as roomService from '../services/roomService.js';
 import { runAgentTask } from '../services/claudeService.js';
 import { READ_ONLY } from '../config.js';
+import { writeAuditLog } from '../services/auditService.js';
+import { checkSocketRateLimit } from '../middleware/rateLimit.js';
+
+interface ZoomAuth {
+  userId?: string;
+  teamId?: string;
+}
+
+function resolveSocketUser(socket: Socket): ZoomAuth {
+  const auth = (socket.handshake.auth ?? {}) as Record<string, unknown>;
+  return {
+    userId: typeof auth['userId'] === 'string' ? auth['userId'] : 'anonymous',
+    teamId: typeof auth['teamId'] === 'string' ? auth['teamId'] : undefined,
+  };
+}
 
 export function registerHandlers(io: Server, socket: Socket): void {
   // Send full agent + team list on connect
@@ -74,5 +90,111 @@ export function registerHandlers(io: Server, socket: Socket): void {
     agentService.getHistory(agentId)
       .then((history) => io.to(`agent:${agentId}`).emit('agent:history', { agentId, history }))
       .catch((err) => console.error(`[socket] agent:resumeSession error for ${agentId}:`, err));
+  });
+
+  // ── Zoom-in authorization gates ───────────────────────────────────────────
+
+  socket.on('agent:zoom-in', ({ agentId }: { agentId: string }) => {
+    const { userId, teamId } = resolveSocketUser(socket);
+
+    if (!checkSocketRateLimit(socket.id)) {
+      socket.emit('zoom:error', {
+        error: 'Too many zoom requests',
+        code: 'RATE_LIMIT_EXCEEDED',
+        resourceType: 'agent',
+        resourceId: agentId,
+      });
+      return;
+    }
+
+    const agent = agentService.getAgent(agentId);
+    const exists = !!agent;
+    const allowed = exists && (teamId === undefined || agent!.teamId === teamId);
+
+    writeAuditLog({
+      timestamp: new Date().toISOString(),
+      event: 'agent:zoom-in',
+      userId: userId ?? 'anonymous',
+      resourceType: 'agent',
+      resourceId: agentId,
+      teamId,
+      allowed,
+    });
+
+    if (!exists) {
+      socket.emit('zoom:error', {
+        error: 'Agent not found',
+        code: 'NOT_FOUND',
+        resourceType: 'agent',
+        resourceId: agentId,
+      });
+      return;
+    }
+
+    if (!allowed) {
+      socket.emit('zoom:error', {
+        error: 'You do not have access to this agent',
+        code: 'ZOOM_FORBIDDEN',
+        resourceType: 'agent',
+        resourceId: agentId,
+      });
+      return;
+    }
+
+    socket.emit('agent:zoom-in:ok', { agent: agentService.toClientAgent(agent!) });
+  });
+
+  socket.on('room:zoom-in', ({ roomId }: { roomId: string }) => {
+    const { userId, teamId } = resolveSocketUser(socket);
+
+    if (!checkSocketRateLimit(socket.id)) {
+      socket.emit('zoom:error', {
+        error: 'Too many zoom requests',
+        code: 'RATE_LIMIT_EXCEEDED',
+        resourceType: 'room',
+        resourceId: roomId,
+      });
+      return;
+    }
+
+    const room = roomService.getAllRooms().find((r) => r.id === roomId);
+    const exists = !!room;
+    let allowed = exists;
+    if (allowed && teamId !== undefined && room!.agentId) {
+      const occupant = agentService.getAgent(room!.agentId);
+      allowed = !occupant || occupant.teamId === teamId;
+    }
+
+    writeAuditLog({
+      timestamp: new Date().toISOString(),
+      event: 'room:zoom-in',
+      userId: userId ?? 'anonymous',
+      resourceType: 'room',
+      resourceId: roomId,
+      teamId,
+      allowed,
+    });
+
+    if (!exists) {
+      socket.emit('zoom:error', {
+        error: 'Room not found',
+        code: 'NOT_FOUND',
+        resourceType: 'room',
+        resourceId: roomId,
+      });
+      return;
+    }
+
+    if (!allowed) {
+      socket.emit('zoom:error', {
+        error: 'You do not have access to this room',
+        code: 'ZOOM_FORBIDDEN',
+        resourceType: 'room',
+        resourceId: roomId,
+      });
+      return;
+    }
+
+    socket.emit('room:zoom-in:ok', { room });
   });
 }


### PR DESCRIPTION
Closes #42

## Summary

- **Audit logging** — every zoom-in attempt (allowed or denied) is appended as a JSONL line to `workspaces/.audit/YYYY-MM-DD.jsonl` with timestamp, userId, resourceType, resourceId, teamId, allowed, and IP
- **Rate limiting** — `server/src/middleware/rateLimit.ts` provides an IP-based HTTP limiter (60 req/min, `X-RateLimit-Limit/Remaining/Reset` headers + 429 on breach) and a per-socket limiter (30 events/min)
- **Zoom middleware** — `server/src/middleware/zoom.ts` exports `requireAgentZoomAccess` / `requireRoomZoomAccess`; checks resource existence and optional team-scoping via `x-user-id` / `x-team-id` headers; returns `{ error, code: "ZOOM_FORBIDDEN", resourceType, resourceId }` on 403
- **Detail REST endpoints** — `GET /api/agents/:id` and `GET /api/rooms/:id` are now rate-limited and zoom-gated
- **Socket events** — `agent:zoom-in` / `room:zoom-in` handlers enforce rate limit + access control; emit `zoom:error` on denial, `agent:zoom-in:ok` / `room:zoom-in:ok` on success; socket handshake `auth.userId` / `auth.teamId` used for identity

## Test plan

- [ ] `GET /api/agents/:id` with no `x-team-id` → 200 + `X-RateLimit-*` headers present
- [ ] `GET /api/agents/:id` with `x-team-id` matching agent's team → 200
- [ ] `GET /api/agents/:id` with `x-team-id` not matching agent's team → 403 `{ code: "ZOOM_FORBIDDEN" }`
- [ ] `GET /api/agents/nonexistent` → 404
- [ ] Exceed 60 requests in 60s from same IP → 429 + `Retry-After` header
- [ ] Socket `agent:zoom-in` with valid agentId → `agent:zoom-in:ok` emitted; audit log entry written
- [ ] Socket `agent:zoom-in` with wrong teamId in handshake auth → `zoom:error` with `ZOOM_FORBIDDEN`
- [ ] Socket `room:zoom-in` with valid roomId → `room:zoom-in:ok` emitted
- [ ] Audit log file appears at `workspaces/.audit/YYYY-MM-DD.jsonl` after first zoom

🤖 Generated with [Claude Code](https://claude.ai/claude-code)