### PR TITLE
feat: REST API endpoints for zoom-in detail views (#40)

### DIFF
--- a/docs/docs/api/rest-api.md
+++ b/docs/docs/api/rest-api.md
@@ -470,3 +470,123 @@ curl -X PUT http://localhost:3001/api/agents/agent_xyz789/files/claude-md \
   -H "Content-Type: application/json" \
   -d '{ "content": "# CLAUDE.md\n\nAgent-specific instructions here." }'
 ```
+
+---
+
+## Detail Views (Zoom)
+
+High-detail snapshots for the zoom-in view. Both endpoints support `limit` / `offset` query parameters for paginating conversation history.
+
+---
+
+### `GET /api/rooms/:id/detail`
+
+Full room snapshot — room grid position, the occupying agent (if any), and the agent's recent conversation messages.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `teamId` | string | `"default"` | Team that owns the room. Required for multi-team deployments because room IDs (`room-01` … `room-15`) repeat across teams. |
+| `limit` | integer | `20` | Max messages to return (1–100). |
+| `offset` | integer | `0` | Number of messages to skip. |
+
+```bash
+curl "http://localhost:3001/api/rooms/room-01/detail?teamId=default&limit=10&offset=0"
+```
+
+**Response** `200 OK`:
+```json
+{
+  "room": {
+    "id": "room-01",
+    "gridCol": 1,
+    "gridRow": 1,
+    "teamId": "default"
+  },
+  "agent": {
+    "id": "agent_xyz789",
+    "name": "assistant",
+    "mission": "You are a helpful assistant.",
+    "avatarColor": "#4f46e5",
+    "status": "sleeping",
+    "roomId": "room-01",
+    "teamId": "default",
+    "canCreateAgents": false,
+    "repoUrl": null,
+    "sessionId": "sess_abc...",
+    "pendingQuestion": null,
+    "lastActivity": "2024-01-15T10:05:00Z",
+    "createdAt": "2024-01-15T10:00:00Z"
+  },
+  "recentMessages": [
+    { "role": "user", "content": "Summarise the Q4 report." },
+    { "role": "assistant", "content": "Here is a summary…" }
+  ],
+  "pagination": {
+    "total": 42,
+    "limit": 10,
+    "offset": 0
+  }
+}
+```
+
+`agent` is `null` when the room is unoccupied. `recentMessages` is `[]` when the agent has no conversation history.
+
+---
+
+### `GET /api/agents/:id/detail`
+
+Full agent snapshot — metadata, workspace `MEMORY.md` content, paginated conversation history, and available SDK sessions.
+
+**Query parameters:**
+
+| Parameter | Type | Default | Description |
+|-----------|------|---------|-------------|
+| `limit` | integer | `20` | Max history messages to return (1–100). |
+| `offset` | integer | `0` | Number of messages to skip. |
+
+```bash
+curl "http://localhost:3001/api/agents/agent_xyz789/detail?limit=20&offset=0"
+```
+
+**Response** `200 OK`:
+```json
+{
+  "agent": {
+    "id": "agent_xyz789",
+    "name": "assistant",
+    "mission": "You are a helpful assistant.",
+    "avatarColor": "#4f46e5",
+    "status": "working",
+    "roomId": "room-01",
+    "teamId": "default",
+    "canCreateAgents": false,
+    "repoUrl": null,
+    "sessionId": "sess_abc...",
+    "pendingQuestion": null,
+    "lastActivity": "2024-01-15T10:05:00Z",
+    "createdAt": "2024-01-15T10:00:00Z"
+  },
+  "memory": {
+    "content": "# Long-term Memory\n\nKey facts the agent has learned…"
+  },
+  "history": {
+    "messages": [
+      { "role": "user", "content": "Analyse the dataset." },
+      { "role": "assistant", "content": "I'll start by…" }
+    ],
+    "pagination": {
+      "total": 84,
+      "limit": 20,
+      "offset": 0
+    }
+  },
+  "sessions": [
+    { "sessionId": "sess_abc...", "createdAt": "2024-01-15T10:00:00Z" },
+    { "sessionId": "sess_def...", "createdAt": "2024-01-14T08:00:00Z" }
+  ]
+}
+```
+
+`memory.content` is `null` when no `MEMORY.md` exists in the agent's workspace. `sessions` lists all persisted SDK sessions for the agent's workspace directory.

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -6,6 +6,7 @@ import { fileURLToPath } from 'url';
 import { dirname, join } from 'path';
 import { PORT, READ_ONLY } from './config.js';
 import { createAgentRouter, createRoomsRouter, createTeamsRouter } from './routes/agents.js';
+import { createDetailRouter } from './routes/detail.js';
 import { createWorkspacesRouter } from './routes/workspaces.js';
 import { createTemplatesRouter } from './routes/templates.js';
 import { createSchedulesRouter } from './routes/schedules.js';
@@ -58,6 +59,7 @@ if (READ_ONLY) {
 app.use('/api/agents', createAgentRouter(io));
 app.use('/api/rooms', createRoomsRouter());
 app.use('/api/teams', createTeamsRouter(io));
+app.use('/api', createDetailRouter(io));
 app.use('/api/workspaces', createWorkspacesRouter());
 app.use('/api/templates', createTemplatesRouter(io));
 app.use('/api/schedules', createSchedulesRouter(io));

--- a/server/src/routes/detail.ts
+++ b/server/src/routes/detail.ts
@@ -1,0 +1,206 @@
+import { existsSync, readFileSync } from 'fs';
+import { join } from 'path';
+import { Router } from 'express';
+import type { Request, Response } from 'express';
+import type { Server } from 'socket.io';
+import * as agentService from '../services/agentService.js';
+import * as roomService from '../services/roomService.js';
+import type { Agent, Room } from '../models/types.js';
+
+// ── Response shape types ─────────────────────────────────────────────────────
+
+export interface RoomSummary {
+  id: string;
+  gridCol: number;
+  gridRow: number;
+  teamId: string;
+}
+
+export interface AgentSummary {
+  id: string;
+  name: string;
+  mission: string;
+  avatarColor: string;
+  status: Agent['status'];
+  roomId: string;
+  teamId: string;
+  canCreateAgents: boolean;
+  repoUrl: string | undefined;
+  sessionId: string | undefined;
+  pendingQuestion: string | undefined;
+  lastActivity: string;
+  createdAt: string;
+}
+
+export interface MessageEntry {
+  role: 'user' | 'assistant';
+  content: string;
+}
+
+export interface Pagination {
+  total: number;
+  limit: number;
+  offset: number;
+}
+
+export interface RoomDetailResponse {
+  room: RoomSummary;
+  agent: AgentSummary | null;
+  recentMessages: MessageEntry[];
+  pagination: Pagination;
+}
+
+// Sessions are passed through as-is from the SDK — type inferred from agentService.
+type SessionList = Awaited<ReturnType<typeof agentService.listAgentSessions>>;
+
+export interface AgentDetailResponse {
+  agent: AgentSummary;
+  memory: { content: string | null };
+  history: {
+    messages: MessageEntry[];
+    pagination: Pagination;
+  };
+  sessions: SessionList;
+}
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function toAgentSummary(agent: Agent): AgentSummary {
+  return {
+    id: agent.id,
+    name: agent.name,
+    mission: agent.mission,
+    avatarColor: agent.avatarColor,
+    status: agent.status,
+    roomId: agent.roomId,
+    teamId: agent.teamId,
+    canCreateAgents: agent.canCreateAgents ?? false,
+    repoUrl: agent.repoUrl,
+    sessionId: agent.sessionId,
+    pendingQuestion: agent.pendingQuestion,
+    lastActivity: agent.lastActivity instanceof Date
+      ? agent.lastActivity.toISOString()
+      : String(agent.lastActivity),
+    createdAt: agent.createdAt instanceof Date
+      ? agent.createdAt.toISOString()
+      : String(agent.createdAt),
+  };
+}
+
+function parsePaginationParams(req: Request): { limit: number; offset: number } {
+  const rawLimit = parseInt(String(req.query.limit ?? '20'), 10);
+  const rawOffset = parseInt(String(req.query.offset ?? '0'), 10);
+  const limit = Math.min(Math.max(Number.isNaN(rawLimit) ? 20 : rawLimit, 1), 100);
+  const offset = Math.max(Number.isNaN(rawOffset) ? 0 : rawOffset, 0);
+  return { limit, offset };
+}
+
+function paginateMessages(
+  messages: MessageEntry[],
+  limit: number,
+  offset: number,
+): { messages: MessageEntry[]; pagination: Pagination } {
+  return {
+    messages: messages.slice(offset, offset + limit),
+    pagination: { total: messages.length, limit, offset },
+  };
+}
+
+function readMemoryMd(workspacePath: string): string | null {
+  const memPath = join(workspacePath, 'MEMORY.md');
+  if (!existsSync(memPath)) return null;
+  try {
+    return readFileSync(memPath, 'utf-8');
+  } catch {
+    return null;
+  }
+}
+
+// ── Router factory ───────────────────────────────────────────────────────────
+
+/**
+ * Mount at `/api` so that:
+ *   GET /api/rooms/:id/detail
+ *   GET /api/agents/:id/detail
+ */
+export function createDetailRouter(_io: Server): Router {
+  const router = Router();
+
+  /**
+   * GET /api/rooms/:id/detail?teamId=<id>&limit=<n>&offset=<n>
+   *
+   * Full room snapshot: room metadata, the occupying agent (if any), and the
+   * agent's recent conversation messages (paginated).
+   *
+   * `teamId` defaults to `"default"` when omitted. Room IDs are per-team
+   * (`room-01` … `room-15`), so the query param is required for multi-team
+   * deployments.
+   */
+  router.get('/rooms/:id/detail', async (req: Request, res: Response): Promise<void> => {
+    const roomId = req.params.id;
+    const teamId =
+      typeof req.query.teamId === 'string' && req.query.teamId.trim()
+        ? req.query.teamId.trim()
+        : 'default';
+    const { limit, offset } = parsePaginationParams(req);
+
+    const teamRooms: Room[] = roomService.getRoomsByTeam(teamId);
+    const room = teamRooms.find((r) => r.id === roomId);
+
+    if (!room) {
+      res.status(404).json({ error: 'Room not found' });
+      return;
+    }
+
+    const agent = room.agentId ? agentService.getAgent(room.agentId) : undefined;
+
+    const rawMessages: MessageEntry[] = agent
+      ? await agentService.getHistory(agent.id)
+      : [];
+
+    const { messages: recentMessages, pagination } = paginateMessages(rawMessages, limit, offset);
+
+    const body: RoomDetailResponse = {
+      room: { id: room.id, gridCol: room.gridCol, gridRow: room.gridRow, teamId },
+      agent: agent ? toAgentSummary(agent) : null,
+      recentMessages,
+      pagination,
+    };
+
+    res.json(body);
+  });
+
+  /**
+   * GET /api/agents/:id/detail?limit=<n>&offset=<n>
+   *
+   * Full agent snapshot: agent metadata, workspace MEMORY.md content,
+   * paginated conversation history, and available SDK sessions.
+   */
+  router.get('/agents/:id/detail', async (req: Request, res: Response): Promise<void> => {
+    const agent = agentService.getAgent(req.params.id);
+    if (!agent) {
+      res.status(404).json({ error: 'Agent not found' });
+      return;
+    }
+
+    const { limit, offset } = parsePaginationParams(req);
+
+    const [rawHistory, sessions] = await Promise.all([
+      agentService.getHistory(agent.id),
+      agentService.listAgentSessions(agent.id),
+    ]);
+
+    const { messages, pagination } = paginateMessages(rawHistory, limit, offset);
+
+    const body: AgentDetailResponse = {
+      agent: toAgentSummary(agent),
+      memory: { content: readMemoryMd(agent.workspacePath) },
+      history: { messages, pagination },
+      sessions,
+    };
+
+    res.json(body);
+  });
+
+  return router;
+}


### PR DESCRIPTION
## Summary

- **`GET /api/rooms/:id/detail`** — full room snapshot: grid position, occupying agent summary, and paginated recent conversation messages. `?teamId=` disambiguates rooms across teams (room IDs repeat per team).
- **`GET /api/agents/:id/detail`** — full agent snapshot: metadata, `MEMORY.md` content, paginated conversation history, and available SDK sessions.
- Both support `?limit=` (1–100, default 20) and `?offset=` pagination on message lists.

## Implementation

- New file: `server/src/routes/detail.ts` — `createDetailRouter(io)` factory, mounted at `/api` in `index.ts`
- Strict TypeScript throughout; no `any`; session list type inferred from `agentService.listAgentSessions` return type
- Response shapes documented in `docs/docs/api/rest-api.md`

## Test plan

- [ ] `GET /api/rooms/room-01/detail` returns `{ room, agent: null, recentMessages: [], pagination }` for an empty room
- [ ] `GET /api/rooms/room-01/detail?teamId=default` returns agent summary and messages when occupied
- [ ] `GET /api/agents/:id/detail` returns full snapshot including `memory.content` and `sessions`
- [ ] `?limit=5&offset=10` correctly slices the message array and reports accurate `pagination.total`
- [ ] `GET /api/rooms/bad-id/detail` → 404; `GET /api/agents/bad-id/detail` → 404
- [ ] `npm run build -w server` passes with no type errors

Closes #40

🤖 Generated with [Claude Code](https://claude.com/claude-code)