### PR TITLE
feat: zoom-in/zoom-out Socket.IO events for detail-level real-time sync (#41)

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,6 +110,84 @@ docker pull ghcr.io/pierredosne-fin/data-platform-tonkatsu:latest
 
 ---
 
+## Socket.IO events
+
+Tonkatsu uses Socket.IO for real-time communication. All events are on the default namespace (`/`).
+
+### Connection
+
+On connect the server immediately emits:
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `agent:list` | `ClientAgent[]` | Full agent roster |
+| `team:list` | `Team[]` | All teams |
+
+### Standard subscriptions (all connected clients)
+
+| Direction | Event | Payload | Description |
+|-----------|-------|---------|-------------|
+| C→S | `agent:subscribe` | `{ agentId }` | Join room `agent:{agentId}`; server sends back `agent:history` |
+| C→S | `agent:unsubscribe` | `{ agentId }` | Leave room `agent:{agentId}` |
+| S→C | `agent:history` | `{ agentId, history }` | Full conversation history (sent to room members) |
+| S→C | `agent:list` | `ClientAgent[]` | Broadcast when roster changes |
+| S→C | `team:list` | `Team[]` | Broadcast when team structure changes |
+| S→C | `agent:created` | `ClientAgent` | New agent spawned |
+| S→C | `agent:updated` | `Partial<ClientAgent>` | Agent properties changed |
+| S→C | `agent:deleted` | `{ agentId }` | Agent removed |
+| S→C | `agent:statusChanged` | `{ agentId, status, pendingQuestion? }` | Status transition |
+| S→C | `agent:message` | `{ agentId, message }` | Completed user or assistant message |
+| S→C | `agent:delegating` | `{ fromAgentId, toAgentId, toAgentName, message }` | Delegation started |
+| S→C | `agent:delegationComplete` | `{ fromAgentId, toAgentId, toAgentName, response }` | Delegation finished |
+| S→C | `agent:error` | `{ agentId, error }` | Agent error |
+| S→C | `agent:sessions` | `{ agentId, sessions }` | Available session list |
+| S→C | `workspace:synced` | `{ agentId }` | Workspace git sync completed |
+
+### Agent control
+
+| Direction | Event | Payload | Description |
+|-----------|-------|---------|-------------|
+| C→S | `agent:sendMessage` | `{ agentId, message }` | Send a user message to an agent |
+| C→S | `agent:sleep` | `{ agentId }` | Abort the current task and set status to sleeping |
+| C→S | `agent:newConversation` | `{ agentId }` | Clear conversation history |
+| C→S | `team:newConversation` | `{ teamId }` | Clear history for all team agents |
+| C→S | `agent:listSessions` | `{ agentId }` | Request available sessions |
+| C→S | `agent:resumeSession` | `{ agentId, sessionId }` | Restore a past session |
+| C→S | `agent:moveRoom` | `{ agentId, targetRoomId }` | Move agent to a different grid room |
+
+### Zoom — detail-level subscriptions
+
+Detail events (streaming tokens, tool calls, tool results) are **only** delivered to clients that have explicitly zoomed in. Non-zoomed clients never receive these high-frequency events.
+
+**Socket.IO room names:**
+- `agent:zoomed:{agentId}` — joined via `agent:zoom-in`
+- `room:detail:{roomId}` — joined via `room:zoom-in`
+
+Detail events are sent to **both** rooms so a client can zoom into either an agent or a grid room and receive the same stream.
+
+#### Zoom control events (Client → Server)
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `agent:zoom-in` | `{ agentId: string }` | Subscribe to detail events for an agent |
+| `agent:zoom-out` | `{ agentId: string }` | Unsubscribe from detail events for an agent |
+| `room:zoom-in` | `{ roomId: string }` | Subscribe to detail events for a grid room |
+| `room:zoom-out` | `{ roomId: string }` | Unsubscribe from detail events for a grid room |
+
+#### Detail events (Server → zoomed clients only)
+
+| Event | Payload | Description |
+|-------|---------|-------------|
+| `agent:stream` | `{ agentId, chunk: string, done: boolean }` | Streaming token chunk. Chunks are batched (≤50 ms) before delivery. `done: true` signals end of stream. |
+| `agent:toolCall` | `{ agentId, toolCallId, tool, input }` | Tool invocation initiated by the agent |
+| `agent:toolResult` | `{ agentId, toolCallId, tool, result }` | Tool result returned to the agent (truncated to 500 chars) |
+
+#### Memory safety
+
+Socket.IO removes sockets from all rooms on disconnect. Throttle timers are keyed by `agentId` and cleared when the stream ends (`done: true`), so no timers outlive a task.
+
+---
+
 ## CI/CD
 
 | Workflow | Trigger | What it does |

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -107,3 +107,37 @@ export interface UserInputPayload {
   agentId: string;
   message: string;
 }
+
+// ── Zoom payload types ────────────────────────────────────────────────────────
+
+/** Client → Server: subscribe to detail events for a grid room. */
+export interface RoomZoomInPayload { roomId: string; }
+/** Client → Server: unsubscribe from detail events for a grid room. */
+export interface RoomZoomOutPayload { roomId: string; }
+/** Client → Server: subscribe to detail events for a specific agent. */
+export interface AgentZoomInPayload { agentId: string; }
+/** Client → Server: unsubscribe from detail events for a specific agent. */
+export interface AgentZoomOutPayload { agentId: string; }
+
+/** Server → Client (zoomed): streaming token chunk from a running agent. */
+export interface AgentStreamEvent {
+  agentId: string;
+  chunk: string;
+  done: boolean;
+}
+
+/** Server → Client (zoomed): tool call initiated by a running agent. */
+export interface AgentToolCallEvent {
+  agentId: string;
+  toolCallId: string;
+  tool: string;
+  input: Record<string, unknown>;
+}
+
+/** Server → Client (zoomed): tool result returned to a running agent. */
+export interface AgentToolResultEvent {
+  agentId: string;
+  toolCallId: string;
+  tool: string;
+  result: string;
+}

--- a/server/src/services/claudeService.ts
+++ b/server/src/services/claudeService.ts
@@ -4,6 +4,7 @@ import type { Server } from 'socket.io';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import * as agentService from './agentService.js';
 import { notifyDesktop } from './notifyService.js';
+import { emitThrottledStream, emitToZoomedRooms } from './zoomService.js';
 
 const NEED_INPUT_RE = /<NEED_INPUT>([\s\S]*?)<\/NEED_INPUT>/;
 const CALL_AGENT_RE = /<CALL_AGENT name="([^"]+)">([\s\S]*?)<\/CALL_AGENT>/;
@@ -124,11 +125,7 @@ async function runSDKQuery(
           }
         } else if (event.type === 'content_block_delta') {
           if (event.delta.type === 'text_delta') {
-            io.to(`agent:${agentId}`).emit('agent:stream', {
-              agentId,
-              chunk: event.delta.text,
-              done: false,
-            });
+            emitThrottledStream(io, agentId, event.delta.text, false);
           } else if (event.delta.type === 'input_json_delta' && pendingToolCall) {
             pendingToolCall.inputStr += event.delta.partial_json;
           }
@@ -137,7 +134,7 @@ async function runSDKQuery(
             try {
               const input = JSON.parse(pendingToolCall.inputStr || '{}') as Record<string, unknown>;
               toolNameById.set(pendingToolCall.id, pendingToolCall.name);
-              io.to(`agent:${agentId}`).emit('agent:toolCall', {
+              emitToZoomedRooms(io, agentId, 'agent:toolCall', {
                 agentId,
                 toolCallId: pendingToolCall.id,
                 tool: pendingToolCall.name,
@@ -177,7 +174,7 @@ async function runSDKQuery(
                     : '';
               const MAX_PREVIEW = 500;
               const preview = rawContent.length > MAX_PREVIEW ? rawContent.slice(0, MAX_PREVIEW) + '…' : rawContent;
-              io.to(`agent:${agentId}`).emit('agent:toolResult', {
+              emitToZoomedRooms(io, agentId, 'agent:toolResult', {
                 agentId,
                 toolCallId: tr.tool_use_id,
                 tool: toolNameById.get(tr.tool_use_id) ?? '',
@@ -190,7 +187,7 @@ async function runSDKQuery(
       }
 
       if (message.type === 'result') {
-        io.to(`agent:${agentId}`).emit('agent:stream', { agentId, chunk: '', done: true });
+        emitThrottledStream(io, agentId, '', true);
         if (message.subtype !== 'success') {
           const errors = (message as { errors?: string[] }).errors ?? [];
           const errorMsg = errors.join('; ');

--- a/server/src/services/zoomService.ts
+++ b/server/src/services/zoomService.ts
@@ -1,0 +1,88 @@
+/**
+ * zoomService — scoped Socket.IO subscriptions for detail-level agent events.
+ *
+ * Room naming convention:
+ *   agent:zoomed:{agentId}  — clients zoomed into a specific agent
+ *   room:detail:{roomId}    — clients zoomed into a specific grid room
+ *
+ * High-frequency stream chunks are throttled (THROTTLE_MS) to avoid flooding
+ * clients. Non-stream detail events (toolCall, toolResult) are emitted immediately.
+ *
+ * Memory-leak safety: Socket.IO removes sockets from rooms automatically on
+ * disconnect. Throttle timers are keyed by agentId and cleared when the stream
+ * ends (done=true), so they never outlive a task.
+ */
+
+import type { Server } from 'socket.io';
+import * as agentService from './agentService.js';
+
+/** Milliseconds between flushed stream-chunk batches per agent. */
+const THROTTLE_MS = 50;
+
+// Accumulated chunks waiting for the next flush, keyed by agentId.
+const pendingChunks = new Map<string, string>();
+// Active flush timers, keyed by agentId.
+const flushTimers = new Map<string, ReturnType<typeof setTimeout>>();
+
+/**
+ * Emit a streaming token chunk to all zoomed clients for this agent.
+ * Chunks are batched and flushed every THROTTLE_MS ms.
+ * Calling with done=true flushes any pending chunk immediately, then signals completion.
+ */
+export function emitThrottledStream(
+  io: Server,
+  agentId: string,
+  chunk: string,
+  done: boolean,
+): void {
+  if (done) {
+    // Flush any remaining accumulated text before signalling completion.
+    const timer = flushTimers.get(agentId);
+    if (timer !== undefined) {
+      clearTimeout(timer);
+      flushTimers.delete(agentId);
+    }
+    const pending = pendingChunks.get(agentId) ?? '';
+    pendingChunks.delete(agentId);
+    if (pending) {
+      emitToZoomedRooms(io, agentId, 'agent:stream', { agentId, chunk: pending, done: false });
+    }
+    emitToZoomedRooms(io, agentId, 'agent:stream', { agentId, chunk: '', done: true });
+    return;
+  }
+
+  // Accumulate the chunk.
+  pendingChunks.set(agentId, (pendingChunks.get(agentId) ?? '') + chunk);
+
+  // Schedule a flush if one is not already pending.
+  if (!flushTimers.has(agentId)) {
+    const timer = setTimeout(() => {
+      flushTimers.delete(agentId);
+      const accumulated = pendingChunks.get(agentId) ?? '';
+      pendingChunks.delete(agentId);
+      if (accumulated) {
+        emitToZoomedRooms(io, agentId, 'agent:stream', { agentId, chunk: accumulated, done: false });
+      }
+    }, THROTTLE_MS);
+    flushTimers.set(agentId, timer);
+  }
+}
+
+/**
+ * Emit a detail event immediately to all zoomed clients for this agent.
+ * Events are sent to:
+ *   - `agent:zoomed:{agentId}` (clients who called agent:zoom-in)
+ *   - `room:detail:{roomId}`   (clients who called room:zoom-in for the agent's room)
+ */
+export function emitToZoomedRooms(
+  io: Server,
+  agentId: string,
+  event: string,
+  payload: Record<string, unknown>,
+): void {
+  io.to(`agent:zoomed:${agentId}`).emit(event, payload);
+  const agent = agentService.getAgent(agentId);
+  if (agent?.roomId) {
+    io.to(`room:detail:${agent.roomId}`).emit(event, payload);
+  }
+}

--- a/server/src/socket/handlers.ts
+++ b/server/src/socket/handlers.ts
@@ -75,4 +75,28 @@ export function registerHandlers(io: Server, socket: Socket): void {
       .then((history) => io.to(`agent:${agentId}`).emit('agent:history', { agentId, history }))
       .catch((err) => console.error(`[socket] agent:resumeSession error for ${agentId}:`, err));
   });
+
+  // ── Zoom — scoped detail-level subscriptions ─────────────────────────────
+  // Socket.IO removes these room memberships automatically on disconnect,
+  // so no explicit cleanup is required.
+
+  /** Subscribe to detail events for a specific grid room. */
+  socket.on('room:zoom-in', ({ roomId }: { roomId: string }) => {
+    socket.join(`room:detail:${roomId}`);
+  });
+
+  /** Unsubscribe from detail events for a specific grid room. */
+  socket.on('room:zoom-out', ({ roomId }: { roomId: string }) => {
+    socket.leave(`room:detail:${roomId}`);
+  });
+
+  /** Subscribe to detail events (stream, toolCall, toolResult) for a specific agent. */
+  socket.on('agent:zoom-in', ({ agentId }: { agentId: string }) => {
+    socket.join(`agent:zoomed:${agentId}`);
+  });
+
+  /** Unsubscribe from detail events for a specific agent. */
+  socket.on('agent:zoom-out', ({ agentId }: { agentId: string }) => {
+    socket.leave(`agent:zoomed:${agentId}`);
+  });
 }


### PR DESCRIPTION
## Summary

- **4 new client events**: `room:zoom-in`, `room:zoom-out`, `agent:zoom-in`, `agent:zoom-out` — join/leave scoped Socket.IO rooms
- **Detail events scoped to zoomed clients only**: `agent:stream`, `agent:toolCall`, `agent:toolResult` now emit exclusively to `agent:zoomed:{agentId}` and `room:detail:{roomId}` — non-zoomed clients never receive high-frequency events
- **50 ms chunk batching** in `zoomService.emitThrottledStream` — token events are accumulated and flushed in batches, reducing event frequency under heavy streaming
- **Zero memory leaks**: Socket.IO removes sockets from rooms on disconnect; throttle timers are keyed by `agentId` and cleared when the stream ends (`done: true`)

## Files changed

| File | Change |
|------|--------|
| `server/src/services/zoomService.ts` | New — throttle logic + `emitThrottledStream` / `emitToZoomedRooms` helpers |
| `server/src/socket/handlers.ts` | Add 4 zoom event handlers |
| `server/src/services/claudeService.ts` | Route stream/toolCall/toolResult through zoomService |
| `server/src/models/types.ts` | Add zoom payload types and detail event interfaces |
| `README.md` | Add full Socket.IO events reference section |

## Test plan

- [ ] Connect two clients; have client A do `agent:zoom-in` and client B stay unzoomed — confirm only A receives `agent:stream` / `agent:toolCall` / `agent:toolResult` while an agent runs
- [ ] `room:zoom-in` for the agent's grid room — confirm client receives the same detail events as an agent-zoomed client
- [ ] Disconnect a zoomed client mid-stream — confirm no errors and no lingering rooms on the server
- [ ] `agent:zoom-out` while agent is streaming — confirm events stop arriving on that socket
- [ ] Verify `agent:history`, `agent:statusChanged`, `agent:message` still reach all `agent:subscribe`d clients (unaffected)

Closes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)