### PR TITLE
feat: visual UX for FAN_OUT parallel task dispatch on board canvas

### DIFF
--- a/client/src/components/AgentAvatar.tsx
+++ b/client/src/components/AgentAvatar.tsx
@@ -6,10 +6,11 @@ interface Props {
 }
 
 const STATUS_ICON: Record<Agent['status'], string> = {
-  sleeping:   '💤',
-  working:    '⚙️',
-  pending:    '❗',
-  delegating: '📨',
+  sleeping:     '💤',
+  working:      '⚙️',
+  pending:      '❗',
+  delegating:   '📨',
+  broadcasting: '📡',
 };
 
 export function AgentAvatar({ agent, onClick }: Props) {

--- a/client/src/components/AgentSidebar.tsx
+++ b/client/src/components/AgentSidebar.tsx
@@ -4,10 +4,11 @@ import { useSocketStore } from '../store/socketStore';
 import type { Agent, CronSchedule } from '../types';
 
 const STATUS_LABEL: Record<Agent['status'], string> = {
-  sleeping:   'Sleeping',
-  working:    'Working',
-  pending:    'Needs input',
-  delegating: 'Waiting for agent',
+  sleeping:     'Sleeping',
+  working:      'Working',
+  pending:      'Needs input',
+  delegating:   'Waiting for agent',
+  broadcasting: 'Broadcasting fan-out',
 };
 
 interface Props {

--- a/client/src/components/FanOutModal.tsx
+++ b/client/src/components/FanOutModal.tsx
@@ -19,6 +19,7 @@ export function FanOutModal() {
   const [step, setStep] = useState<Step>('confirm');
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [expandedTasks, setExpandedTasks] = useState<Set<number>>(new Set());
   const [selectedCron, setSelectedCron] = useState(CRON_OPTIONS[1].cron);
   const [selectedTtlMs, setSelectedTtlMs] = useState(TTL_OPTIONS[1].ms);
 
@@ -26,15 +27,20 @@ export function FanOutModal() {
 
   const fromAgent = agents.find((a) => a.id === proposal.fromAgentId);
 
+  const toggleExpanded = (i: number) => {
+    setExpandedTasks((prev) => {
+      const next = new Set(prev);
+      if (next.has(i)) next.delete(i); else next.add(i);
+      return next;
+    });
+  };
+
   const confirm = async () => {
     setLoading(true);
     setError(null);
     try {
       const res = await fetch(`/api/fan-out/${proposal.id}/confirm`, { method: 'POST' });
-      if (!res.ok) {
-        setError('Dispatch failed — please try again.');
-        return;
-      }
+      if (!res.ok) { setError('Dispatch failed — please try again.'); return; }
       setStep('cron');
     } catch {
       setError('Network error — please try again.');
@@ -70,10 +76,7 @@ export function FanOutModal() {
           ttlMs: selectedTtlMs,
         }),
       });
-      if (!res.ok) {
-        setError('Failed to create schedule — please try again.');
-        return;
-      }
+      if (!res.ok) { setError('Failed to create schedule — please try again.'); return; }
       setPendingFanOut(null);
     } catch {
       setError('Network error — please try again.');
@@ -82,71 +85,49 @@ export function FanOutModal() {
     }
   };
 
+  // ── Cron scheduling step (post-dispatch) ─────────────────────────────────
   if (step === 'cron') {
     return (
-      <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-        <div className="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-md mx-4 p-6 space-y-4">
-          <div>
-            <h2 className="text-white font-semibold text-lg">Tasks dispatched</h2>
-            <p className="text-zinc-400 text-sm mt-1">
-              Would you like <span className="text-white">{fromAgent?.name ?? 'the agent'}</span> to
-              periodically check on progress?
+      <div className="fanout-overlay">
+        <div className="fanout-dialog">
+          <div className="fanout-dialog__header">
+            <div className="fanout-dialog__title">Tasks dispatched</div>
+            <p className="fanout-dialog__subtitle">
+              Would you like <strong>{fromAgent?.name ?? 'the agent'}</strong> to periodically check on progress?
             </p>
           </div>
 
-          <div>
-            <p className="text-zinc-500 text-xs mb-2">Check interval</p>
-            <div className="grid grid-cols-2 gap-2">
+          <div className="fanout-dialog__section">
+            <p className="fanout-dialog__section-label">Check interval</p>
+            <div className="fanout-dialog__grid fanout-dialog__grid--2">
               {CRON_OPTIONS.map((opt) => (
                 <button
                   key={opt.cron}
+                  className={`fanout-chip ${selectedCron === opt.cron ? 'fanout-chip--active' : ''}`}
                   onClick={() => setSelectedCron(opt.cron)}
-                  className={`px-3 py-2 rounded-lg text-sm font-medium transition border ${
-                    selectedCron === opt.cron
-                      ? 'bg-indigo-600 border-indigo-500 text-white'
-                      : 'bg-zinc-800 border-zinc-700 text-zinc-300 hover:bg-zinc-700'
-                  }`}
-                >
-                  {opt.label}
-                </button>
+                >{opt.label}</button>
               ))}
             </div>
           </div>
 
-          <div>
-            <p className="text-zinc-500 text-xs mb-2">Stop after</p>
-            <div className="grid grid-cols-4 gap-2">
+          <div className="fanout-dialog__section">
+            <p className="fanout-dialog__section-label">Stop after</p>
+            <div className="fanout-dialog__grid fanout-dialog__grid--4">
               {TTL_OPTIONS.map((opt) => (
                 <button
                   key={opt.ms}
+                  className={`fanout-chip ${selectedTtlMs === opt.ms ? 'fanout-chip--active' : ''}`}
                   onClick={() => setSelectedTtlMs(opt.ms)}
-                  className={`px-3 py-2 rounded-lg text-sm font-medium transition border ${
-                    selectedTtlMs === opt.ms
-                      ? 'bg-indigo-600 border-indigo-500 text-white'
-                      : 'bg-zinc-800 border-zinc-700 text-zinc-300 hover:bg-zinc-700'
-                  }`}
-                >
-                  {opt.label}
-                </button>
+                >{opt.label}</button>
               ))}
             </div>
           </div>
 
-          {error && <p className="text-red-400 text-xs">{error}</p>}
+          {error && <p className="fanout-dialog__error">{error}</p>}
 
-          <div className="flex gap-3 pt-1">
-            <button
-              onClick={() => setPendingFanOut(null)}
-              disabled={loading}
-              className="flex-1 px-4 py-2 rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition text-sm font-medium"
-            >
-              Skip
-            </button>
-            <button
-              onClick={scheduleCron}
-              disabled={loading}
-              className="flex-1 px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 transition text-sm font-medium disabled:opacity-50"
-            >
+          <div className="fanout-dialog__footer">
+            <button className="fanout-btn fanout-btn--ghost" onClick={() => setPendingFanOut(null)} disabled={loading}>Skip</button>
+            <button className="fanout-btn fanout-btn--primary" onClick={scheduleCron} disabled={loading}>
               {loading ? 'Scheduling…' : 'Set up cron'}
             </button>
           </div>
@@ -155,46 +136,76 @@ export function FanOutModal() {
     );
   }
 
+  // ── Confirmation step ─────────────────────────────────────────────────────
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60">
-      <div className="bg-zinc-900 border border-zinc-700 rounded-xl shadow-2xl w-full max-w-md mx-4 p-6 space-y-4">
-        <div>
-          <h2 className="text-white font-semibold text-lg">Parallel task dispatch</h2>
-          <p className="text-zinc-400 text-sm mt-1">
-            <span className="text-white">{fromAgent?.name ?? 'An agent'}</span> wants to assign{' '}
-            {proposal.tasks.length} task{proposal.tasks.length !== 1 ? 's' : ''} in parallel.
-          </p>
+    <div className="fanout-overlay">
+      <div className="fanout-dialog">
+        {/* Header */}
+        <div className="fanout-dialog__header">
+          {fromAgent && (
+            <div
+              className="fanout-dialog__source-avatar"
+              style={{ background: fromAgent.avatarColor }}
+            >
+              {fromAgent.name[0].toUpperCase()}
+            </div>
+          )}
+          <div>
+            <div className="fanout-dialog__title">Dispatch parallel tasks?</div>
+            <p className="fanout-dialog__subtitle">
+              <strong>{fromAgent?.name ?? 'An agent'}</strong> wants to assign{' '}
+              {proposal.tasks.length} task{proposal.tasks.length !== 1 ? 's' : ''} in parallel.
+            </p>
+          </div>
         </div>
 
-        <ul className="space-y-2">
-          {proposal.tasks.map((task, i) => (
-            <li key={i} className="bg-zinc-800 rounded-lg px-4 py-3">
-              <div className="text-xs text-zinc-400 uppercase tracking-wide mb-1">{task.agent}</div>
-              <div className="text-zinc-200 text-sm line-clamp-2">{task.prompt}</div>
-            </li>
-          ))}
+        {/* Task list */}
+        <ul className="fanout-task-list">
+          {proposal.tasks.map((task, i) => {
+            const targetAgent = agents.find((a) => a.name.toLowerCase() === task.agent.toLowerCase());
+            const isBusy = targetAgent?.status === 'working' || targetAgent?.status === 'pending';
+            const isExpanded = expandedTasks.has(i);
+            const isLong = task.prompt.length > 120;
+
+            return (
+              <li key={i} className="fanout-task-card">
+                <div className="fanout-task-card__header">
+                  <div className="fanout-task-card__agent">
+                    {targetAgent && (
+                      <span
+                        className="fanout-task-card__avatar"
+                        style={{ background: targetAgent.avatarColor }}
+                      >
+                        {targetAgent.name[0].toUpperCase()}
+                      </span>
+                    )}
+                    <span className="fanout-task-card__agent-name">{task.agent}</span>
+                  </div>
+                  {isBusy && <span className="fanout-task-card__busy">⚠ busy</span>}
+                </div>
+                <p className={`fanout-task-card__prompt ${!isExpanded && isLong ? 'fanout-task-card__prompt--clamp' : ''}`}>
+                  {task.prompt}
+                </p>
+                {isLong && (
+                  <button className="fanout-task-card__expand" onClick={() => toggleExpanded(i)}>
+                    {isExpanded ? '▴ show less' : '▾ show more'}
+                  </button>
+                )}
+              </li>
+            );
+          })}
         </ul>
 
-        <p className="text-zinc-500 text-xs">
-          Agents will start immediately and work independently. You will not receive a combined result.
+        <p className="fanout-dialog__hint">
+          Agents will start immediately and work independently.
         </p>
 
-        {error && <p className="text-red-400 text-xs">{error}</p>}
+        {error && <p className="fanout-dialog__error">{error}</p>}
 
-        <div className="flex gap-3 pt-1">
-          <button
-            onClick={reject}
-            disabled={loading}
-            className="flex-1 px-4 py-2 rounded-lg bg-zinc-800 text-zinc-300 hover:bg-zinc-700 transition text-sm font-medium"
-          >
-            Reject
-          </button>
-          <button
-            onClick={confirm}
-            disabled={loading}
-            className="flex-1 px-4 py-2 rounded-lg bg-indigo-600 text-white hover:bg-indigo-500 transition text-sm font-medium disabled:opacity-50"
-          >
-            {loading ? 'Dispatching…' : `Dispatch ${proposal.tasks.length} tasks`}
+        <div className="fanout-dialog__footer">
+          <button className="fanout-btn fanout-btn--ghost" onClick={reject} disabled={loading}>Cancel</button>
+          <button className="fanout-btn fanout-btn--primary" onClick={confirm} disabled={loading}>
+            {loading ? 'Dispatching…' : `Dispatch ${proposal.tasks.length} tasks →`}
           </button>
         </div>
       </div>

--- a/client/src/components/FanOutProgressPanel.tsx
+++ b/client/src/components/FanOutProgressPanel.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react';
+import { useAgentStore } from '../store/agentStore';
+import type { FanOutState, FanOutTaskStatus } from '../types';
+
+interface Props {
+  fanOut: FanOutState;
+  onAgentClick: (agentId: string) => void;
+}
+
+function elapsed(ms: number): string {
+  const s = Math.round(ms / 1000);
+  if (s < 60) return `${s}s ago`;
+  return `${Math.round(s / 60)}m ago`;
+}
+
+const TASK_META: Record<FanOutTaskStatus, { icon: string; cls: string; label: (t: number | undefined) => string }> = {
+  queued:  { icon: '○', cls: 'fo-task--queued',  label: () => 'Queued' },
+  running: { icon: '●', cls: 'fo-task--running', label: () => 'Working…' },
+  done:    { icon: '✓', cls: 'fo-task--done',    label: (t) => t ? `Done · ${elapsed(Date.now() - t)}` : 'Done' },
+  failed:  { icon: '✕', cls: 'fo-task--failed',  label: (t) => t ? `Failed · ${elapsed(Date.now() - t)}` : 'Failed' },
+};
+
+function TaskRow({ task, onAgentClick }: { task: FanOutState['tasks'][number]; onAgentClick: (id: string) => void }) {
+  const agents = useAgentStore((s) => s.agents);
+  const agent = agents.find((a) => a.id === task.targetAgentId);
+  const meta = TASK_META[task.status];
+  const [, setTick] = useState(0);
+
+  // Re-render every 5s to update elapsed labels
+  useEffect(() => {
+    if (task.status !== 'done' && task.status !== 'failed') return;
+    const t = setInterval(() => setTick((n) => n + 1), 5000);
+    return () => clearInterval(t);
+  }, [task.status]);
+
+  return (
+    <li
+      className={`fo-task ${meta.cls}`}
+      onClick={() => onAgentClick(task.targetAgentId)}
+      title="Open agent chat"
+    >
+      <span className="fo-task__icon">{meta.icon}</span>
+      {agent && (
+        <span
+          className="fo-task__avatar"
+          style={{ background: agent.avatarColor }}
+        >
+          {agent.name[0].toUpperCase()}
+        </span>
+      )}
+      <span className="fo-task__name">{agent?.name ?? task.targetAgentId}</span>
+      <span className="fo-task__label">{meta.label(task.completedAt)}</span>
+      {task.status === 'failed' && <span className="fo-task__hint">see chat</span>}
+    </li>
+  );
+}
+
+export function FanOutProgressPanel({ fanOut, onAgentClick }: Props) {
+  const dismissFanOut = useAgentStore((s) => s.dismissFanOut);
+
+  const total = fanOut.tasks.length;
+  const done = fanOut.tasks.filter((t) => t.status === 'done').length;
+  const failed = fanOut.tasks.filter((t) => t.status === 'failed').length;
+  const settled = fanOut.settled;
+  const allDone = done === total;
+  const hasFailure = failed > 0;
+
+  // Auto-collapse after 4s if all succeeded
+  useEffect(() => {
+    if (!settled || hasFailure) return;
+    const t = setTimeout(() => dismissFanOut(fanOut.fanoutId), 4000);
+    return () => clearTimeout(t);
+  }, [settled, hasFailure, fanOut.fanoutId, dismissFanOut]);
+
+  const panelCls = [
+    'fo-panel',
+    settled && allDone ? 'fo-panel--success' : '',
+    settled && hasFailure ? 'fo-panel--failure' : '',
+  ].filter(Boolean).join(' ');
+
+  const pct = total > 0 ? Math.round((done / total) * 100) : 0;
+
+  return (
+    <div className={panelCls}>
+      <div className="fo-panel__header">
+        <span className="fo-panel__title">📡 Fan-out: {total} task{total !== 1 ? 's' : ''}</span>
+        <span className="fo-panel__progress-label">{done} of {total} done</span>
+        <button
+          className="fo-panel__dismiss"
+          onClick={() => dismissFanOut(fanOut.fanoutId)}
+          title="Dismiss"
+        >✕</button>
+      </div>
+
+      <ul className="fo-task-list">
+        {fanOut.tasks.map((task) => (
+          <TaskRow key={task.taskId} task={task} onAgentClick={onAgentClick} />
+        ))}
+      </ul>
+
+      <div className="fo-panel__progress-bar">
+        <div className="fo-panel__progress-fill" style={{ width: `${pct}%` }} />
+      </div>
+      <div className="fo-panel__pct">{pct}%</div>
+    </div>
+  );
+}
+
+/** Renders all active fan-out panels, positioned below their source agent's room. */
+interface PanelsProps {
+  gridRef: React.RefObject<HTMLDivElement | null>;
+  onAgentClick: (agentId: string) => void;
+}
+
+export function FanOutPanels({ gridRef, onAgentClick }: PanelsProps) {
+  const activeFanOuts = useAgentStore((s) => s.activeFanOuts);
+  const agents = useAgentStore((s) => s.agents);
+  const [positions, setPositions] = useState<Map<string, { left: number; top: number }>>(new Map());
+
+  useEffect(() => {
+    if (!gridRef.current || activeFanOuts.size === 0) { setPositions(new Map()); return; }
+    const gridRect = gridRef.current.getBoundingClientRect();
+    const next = new Map<string, { left: number; top: number }>();
+    for (const [fanoutId, fanOut] of activeFanOuts) {
+      const source = agents.find((a) => a.id === fanOut.sourceAgentId);
+      if (!source) continue;
+      const el = gridRef.current.querySelector<HTMLElement>(`[data-room-id="${source.roomId}"]`);
+      if (!el) continue;
+      const r = el.getBoundingClientRect();
+      next.set(fanoutId, {
+        left: r.left - gridRect.left,
+        top: r.bottom - gridRect.top + 8,
+      });
+    }
+    setPositions(next);
+  }, [activeFanOuts, agents, gridRef]);
+
+  return (
+    <>
+      {Array.from(activeFanOuts.values()).map((fanOut) => {
+        const pos = positions.get(fanOut.fanoutId);
+        if (!pos) return null;
+        return (
+          <div
+            key={fanOut.fanoutId}
+            className="fo-panel-anchor"
+            style={{ left: pos.left, top: pos.top }}
+          >
+            <FanOutProgressPanel fanOut={fanOut} onAgentClick={onAgentClick} />
+          </div>
+        );
+      })}
+    </>
+  );
+}

--- a/client/src/components/FanOutProgressPanel.tsx
+++ b/client/src/components/FanOutProgressPanel.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from 'react';
+import { useEffect, useState, type RefObject } from 'react';
 import { useAgentStore } from '../store/agentStore';
 import type { FanOutState, FanOutTaskStatus } from '../types';
 
@@ -108,7 +108,7 @@ export function FanOutProgressPanel({ fanOut, onAgentClick }: Props) {
 
 /** Renders all active fan-out panels, positioned below their source agent's room. */
 interface PanelsProps {
-  gridRef: React.RefObject<HTMLDivElement | null>;
+  gridRef: RefObject<HTMLDivElement | null>;
   onAgentClick: (agentId: string) => void;
 }
 

--- a/client/src/components/OfficeMap.tsx
+++ b/client/src/components/OfficeMap.tsx
@@ -2,6 +2,7 @@ import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
 import { useAgentStore } from '../store/agentStore';
 import { useSocketStore } from '../store/socketStore';
 import { Room } from './Room';
+import { FanOutPanels } from './FanOutProgressPanel';
 import type { Agent, Room as RoomType } from '../types';
 
 const GRID_COLS = 5;
@@ -30,6 +31,21 @@ interface DelegationLine {
   color: string;
 }
 
+interface FanLine {
+  x1: number; y1: number;
+  x2: number; y2: number;
+  color: string;      // target agent's avatar color
+  taskId: string;
+  status: 'queued' | 'running' | 'done' | 'failed';
+}
+
+interface HaloRect {
+  left: number;
+  top: number;
+  right: number;
+  bottom: number;
+}
+
 interface DragState {
   agent: Agent;
   sourceRoomId: string;
@@ -48,6 +64,7 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
   const agents = useAgentStore((s) => s.agents);
   const currentTeamId = useAgentStore((s) => s.currentTeamId);
   const activeDelegations = useAgentStore((s) => s.activeDelegations);
+  const activeFanOuts = useAgentStore((s) => s.activeFanOuts);
   const swapAgentRooms = useAgentStore((s) => s.swapAgentRooms);
   const moveAgentRoom = useSocketStore((s) => s.moveAgentRoom);
 
@@ -64,6 +81,8 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
   const [drag, setDrag] = useState<DragState | null>(null);
   const [hoverRoomId, setHoverRoomId] = useState<string | null>(null);
   const [lines, setLines] = useState<DelegationLine[]>([]);
+  const [fanLines, setFanLines] = useState<FanLine[]>([]);
+  const [halos, setHalos] = useState<HaloRect[]>([]);
 
   const hoverRoomRef = useRef<string | null>(null);
   const agentByRoomRef = useRef<Map<string, Agent>>(new Map());
@@ -122,11 +141,78 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
     setLines(result);
   }, [activeDelegations, teamAgents]);
 
+  // ── Fan lines + halo ──────────────────────────────────────────────────────
+
+  const computeFanLines = useCallback(() => {
+    if (!gridRef.current || activeFanOuts.size === 0) {
+      setFanLines([]);
+      setHalos([]);
+      return;
+    }
+    const gridRect = gridRef.current.getBoundingClientRect();
+    const newFanLines: FanLine[] = [];
+    const newHalos: HaloRect[] = [];
+
+    for (const fanOut of activeFanOuts.values()) {
+      if (fanOut.settled) continue;
+
+      const sourceAgent = teamAgents.find((a) => a.id === fanOut.sourceAgentId);
+      if (!sourceAgent) continue;
+      const sourceEl = gridRef.current.querySelector<HTMLElement>(`[data-room-id="${sourceAgent.roomId}"]`);
+      if (!sourceEl) continue;
+      const sr = sourceEl.getBoundingClientRect();
+      const sx = sr.left - gridRect.left + sr.width / 2;
+      const sy = sr.top - gridRect.top + sr.height / 2;
+
+      // Halo bounding box — starts with source room
+      let hLeft = sr.left - gridRect.left;
+      let hTop = sr.top - gridRect.top;
+      let hRight = sr.right - gridRect.left;
+      let hBottom = sr.bottom - gridRect.top;
+
+      for (const task of fanOut.tasks) {
+        // Skip completed (faded out) tasks' lines
+        if (task.status === 'done') continue;
+
+        const targetAgent = teamAgents.find((a) => a.id === task.targetAgentId);
+        if (!targetAgent) continue;
+        const targetEl = gridRef.current.querySelector<HTMLElement>(`[data-room-id="${targetAgent.roomId}"]`);
+        if (!targetEl) continue;
+        const tr = targetEl.getBoundingClientRect();
+        const tx = tr.left - gridRect.left + tr.width / 2;
+        const ty = tr.top - gridRect.top + tr.height / 2;
+
+        newFanLines.push({
+          x1: sx, y1: sy, x2: tx, y2: ty,
+          color: task.status === 'failed' ? '#ef4444' : targetAgent.avatarColor,
+          taskId: task.taskId,
+          status: task.status,
+        });
+
+        // Expand halo to include target room
+        hLeft   = Math.min(hLeft,   tr.left  - gridRect.left);
+        hTop    = Math.min(hTop,    tr.top   - gridRect.top);
+        hRight  = Math.max(hRight,  tr.right - gridRect.left);
+        hBottom = Math.max(hBottom, tr.bottom - gridRect.top);
+      }
+
+      newHalos.push({ left: hLeft, top: hTop, right: hRight, bottom: hBottom });
+    }
+
+    setFanLines(newFanLines);
+    setHalos(newHalos);
+  }, [activeFanOuts, teamAgents]);
+
   useEffect(() => { computeLines(); }, [computeLines]);
+  useEffect(() => { computeFanLines(); }, [computeFanLines]);
   useEffect(() => {
     window.addEventListener('resize', computeLines);
-    return () => window.removeEventListener('resize', computeLines);
-  }, [computeLines]);
+    window.addEventListener('resize', computeFanLines);
+    return () => {
+      window.removeEventListener('resize', computeLines);
+      window.removeEventListener('resize', computeFanLines);
+    };
+  }, [computeLines, computeFanLines]);
 
   // ── Card drag ─────────────────────────────────────────────────────────────
 
@@ -211,10 +297,8 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
   // ── Pan (click-drag on background) ───────────────────────────────────────
 
   const onBoardMouseDown = useCallback((e: React.MouseEvent<HTMLDivElement>) => {
-    // Ignore if clicking inside a room card or zoom controls
     if ((e.target as Element).closest('[data-room-id]')) return;
     if ((e.target as Element).closest('.zoom-controls')) return;
-    // Ignore if a card drag is already active
     if (dragRef.current) return;
 
     e.preventDefault();
@@ -287,6 +371,8 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
 
   // ── Render ────────────────────────────────────────────────────────────────
 
+  const hasSvgContent = lines.length > 0 || fanLines.length > 0 || halos.length > 0;
+
   return (
     <div
       className={`office-map${isPanning ? ' is-panning' : ''}`}
@@ -314,18 +400,39 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
             />
           ))}
 
-          {lines.length > 0 && (
+          {hasSvgContent && (
             <svg className="office-delegation-svg" aria-hidden="true">
               <defs>
                 {lines.map((line, i) => (
-                  <marker key={i} id={`arrow-${i}`} markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                  <marker key={`dl-${i}`} id={`arrow-${i}`} markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
                     <path d="M0,0 L0,6 L6,3 z" fill={line.color} opacity="0.8" />
                   </marker>
                 ))}
+                {fanLines.map((fl, i) => (
+                  <marker key={`fl-${i}`} id={`fan-arrow-${i}`} markerWidth="6" markerHeight="6" refX="5" refY="3" orient="auto">
+                    <path d="M0,0 L0,6 L6,3 z" fill={fl.color} opacity="0.8" />
+                  </marker>
+                ))}
               </defs>
+
+              {/* Fan-out halos */}
+              {halos.map((h, i) => (
+                <rect
+                  key={`halo-${i}`}
+                  x={h.left - 8} y={h.top - 8}
+                  width={h.right - h.left + 16} height={h.bottom - h.top + 16}
+                  rx="12"
+                  fill="rgba(139,92,246,0.04)"
+                  stroke="rgba(139,92,246,0.2)"
+                  strokeWidth="1" strokeDasharray="4 3"
+                  className="fanout-halo"
+                />
+              ))}
+
+              {/* Delegation lines */}
               {lines.map((line, i) => (
                 <line
-                  key={i}
+                  key={`dl-${i}`}
                   x1={line.x1} y1={line.y1} x2={line.x2} y2={line.y2}
                   stroke={line.color} strokeWidth="2" strokeDasharray="8 5"
                   strokeLinecap="round" opacity="0.75"
@@ -333,10 +440,25 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
                   className="delegation-dash-line"
                 />
               ))}
+
+              {/* Fan lines */}
+              {fanLines.map((fl, i) => (
+                <line
+                  key={`fl-${i}`}
+                  x1={fl.x1} y1={fl.y1} x2={fl.x2} y2={fl.y2}
+                  stroke={fl.color} strokeWidth="2" strokeDasharray="8 5"
+                  strokeLinecap="round"
+                  opacity={fl.status === 'failed' ? '0.9' : '0.75'}
+                  markerEnd={`url(#fan-arrow-${i})`}
+                  className={fl.status === 'failed' ? 'fanout-line--failed' : 'delegation-dash-line'}
+                />
+              ))}
             </svg>
           )}
+
+          {/* Fan-out progress panels anchored below dispatching rooms */}
+          <FanOutPanels gridRef={gridRef} onAgentClick={onAgentClick} />
         </div>
-      </div>
 
       {/* Floating drag ghost (viewport-fixed, unaffected by board transform) */}
       {drag && (

--- a/client/src/components/OfficeMap.tsx
+++ b/client/src/components/OfficeMap.tsx
@@ -459,6 +459,7 @@ export function OfficeMap({ onAgentClick, onEmptyRoomClick, onEditAgent, onDelet
           {/* Fan-out progress panels anchored below dispatching rooms */}
           <FanOutPanels gridRef={gridRef} onAgentClick={onAgentClick} />
         </div>
+      </div>
 
       {/* Floating drag ghost (viewport-fixed, unaffected by board transform) */}
       {drag && (

--- a/client/src/components/Room.tsx
+++ b/client/src/components/Room.tsx
@@ -143,6 +143,9 @@ export function Room({
       {agent?.status === 'delegating' && (
         <div className="room-delegating-badge">Waiting for agent</div>
       )}
+      {agent?.status === 'broadcasting' && (
+        <div className="room-broadcasting-badge">📡 Fan-out</div>
+      )}
     </div>
   );
 }

--- a/client/src/components/ToastStack.tsx
+++ b/client/src/components/ToastStack.tsx
@@ -2,10 +2,11 @@ import { useToastStore, type Toast } from '../store/toastStore';
 import type { AgentStatus } from '../types';
 
 const STATUS_META: Record<AgentStatus, { label: string; icon: string; cls: string }> = {
-  working:    { label: 'Working',            icon: '⚙️',  cls: 'toast--working'    },
-  pending:    { label: 'Needs input',        icon: '❗',  cls: 'toast--pending'    },
-  sleeping:   { label: 'Done',              icon: '💤',  cls: 'toast--sleeping'   },
-  delegating: { label: 'Waiting for agent', icon: '📨',  cls: 'toast--delegating' },
+  working:      { label: 'Working',            icon: '⚙️',  cls: 'toast--working'      },
+  pending:      { label: 'Needs input',        icon: '❗',  cls: 'toast--pending'      },
+  sleeping:     { label: 'Done',              icon: '💤',  cls: 'toast--sleeping'     },
+  delegating:   { label: 'Waiting for agent', icon: '📨',  cls: 'toast--delegating'   },
+  broadcasting: { label: 'Broadcasting',      icon: '📡',  cls: 'toast--broadcasting' },
 };
 
 function ToastItem({ toast }: { toast: Toast }) {
@@ -21,7 +22,9 @@ function ToastItem({ toast }: { toast: Toast }) {
         <div className="toast-name">{toast.agentName}</div>
         <div className="toast-status">
           <span className="toast-icon">{meta.icon}</span>
-          {toast.status === 'pending' && toast.pendingQuestion
+          {toast.customMessage
+            ? toast.customMessage
+            : toast.status === 'pending' && toast.pendingQuestion
             ? toast.pendingQuestion
             : meta.label}
         </div>

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1982,3 +1982,405 @@ body.is-dragging * {
   justify-content: space-between;
   margin-bottom: 6px;
 }
+
+/* ── Broadcasting room state ──────────────────── */
+.room--broadcasting {
+  border-color: #8b5cf6;
+  animation: room-broadcasting-pulse 1.8s ease-in-out infinite;
+}
+
+@keyframes room-broadcasting-pulse {
+  0%, 100% { box-shadow: 0 0 0 1px #8b5cf6, 0 4px 20px rgba(139,92,246,0.15); }
+  50%       { box-shadow: 0 0 0 4px rgba(139,92,246,0.4), 0 4px 32px rgba(139,92,246,0.35); }
+}
+
+.room-broadcasting-badge {
+  position: absolute;
+  top: 8px;
+  right: 8px;
+  background: #8b5cf6;
+  color: #fff;
+  font-size: 10px;
+  font-weight: 700;
+  padding: 2px 6px;
+  border-radius: 99px;
+  white-space: nowrap;
+}
+
+/* ── Fan-out canvas elements ──────────────────── */
+.fanout-halo {
+  pointer-events: none;
+}
+
+.fanout-line--failed {
+  /* no animation — static red line */
+  opacity: 0.9;
+}
+
+/* ── Fan-out confirmation dialog ──────────────── */
+.fanout-overlay {
+  position: fixed;
+  inset: 0;
+  z-index: 50;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(0,0,0,0.6);
+}
+
+.fanout-dialog {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 20px 60px rgba(0,0,0,0.5);
+  width: 100%;
+  max-width: 440px;
+  margin: 0 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 20px;
+  max-height: 90vh;
+  overflow-y: auto;
+}
+
+.fanout-dialog__header {
+  display: flex;
+  align-items: flex-start;
+  gap: 12px;
+}
+
+.fanout-dialog__source-avatar {
+  width: 36px;
+  height: 36px;
+  border-radius: 50%;
+  flex-shrink: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  font-weight: 700;
+  font-size: 15px;
+  color: #fff;
+}
+
+.fanout-dialog__title {
+  font-size: 15px;
+  font-weight: 700;
+  color: var(--text);
+  line-height: 1.3;
+}
+
+.fanout-dialog__subtitle {
+  font-size: 13px;
+  color: var(--text-dim);
+  margin-top: 3px;
+}
+
+.fanout-dialog__subtitle strong { color: var(--text); }
+
+.fanout-task-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.fanout-task-card {
+  background: var(--surface2);
+  border: 1px solid var(--border);
+  border-radius: var(--radius-sm);
+  padding: 10px 12px;
+}
+
+.fanout-task-card__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 6px;
+}
+
+.fanout-task-card__agent {
+  display: flex;
+  align-items: center;
+  gap: 7px;
+}
+
+.fanout-task-card__avatar {
+  width: 18px;
+  height: 18px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 9px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.fanout-task-card__agent-name {
+  font-size: 11px;
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--text-dim);
+}
+
+.fanout-task-card__busy {
+  font-size: 10px;
+  font-weight: 700;
+  color: var(--orange);
+  background: rgba(245,158,11,0.12);
+  border: 1px solid rgba(245,158,11,0.3);
+  padding: 2px 6px;
+  border-radius: 99px;
+}
+
+.fanout-task-card__prompt {
+  font-size: 13px;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.fanout-task-card__prompt--clamp {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  overflow: hidden;
+}
+
+.fanout-task-card__expand {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 11px;
+  cursor: pointer;
+  padding: 2px 0;
+  margin-top: 4px;
+}
+.fanout-task-card__expand:hover { color: var(--text); }
+
+.fanout-dialog__hint {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+.fanout-dialog__error {
+  font-size: 12px;
+  color: var(--red);
+}
+
+.fanout-dialog__section-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  margin-bottom: 8px;
+}
+
+.fanout-dialog__grid {
+  display: grid;
+  gap: 8px;
+}
+.fanout-dialog__grid--2 { grid-template-columns: repeat(2, 1fr); }
+.fanout-dialog__grid--4 { grid-template-columns: repeat(4, 1fr); }
+
+.fanout-chip {
+  padding: 7px 10px;
+  border-radius: var(--radius-sm);
+  border: 1px solid var(--border);
+  background: var(--surface2);
+  color: var(--text-dim);
+  font-size: 12px;
+  font-weight: 500;
+  cursor: pointer;
+  transition: background 0.12s, border-color 0.12s, color 0.12s;
+  text-align: center;
+}
+.fanout-chip:hover { background: var(--surface); color: var(--text); }
+.fanout-chip--active {
+  background: rgba(139,92,246,0.15);
+  border-color: var(--accent);
+  color: var(--accent);
+}
+
+.fanout-dialog__footer {
+  display: flex;
+  gap: 10px;
+}
+
+.fanout-btn {
+  flex: 1;
+  padding: 9px 16px;
+  border-radius: var(--radius-sm);
+  font-size: 13px;
+  font-weight: 600;
+  cursor: pointer;
+  border: none;
+  transition: background 0.12s, opacity 0.12s;
+}
+.fanout-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+
+.fanout-btn--ghost {
+  background: var(--surface2);
+  color: var(--text-dim);
+}
+.fanout-btn--ghost:hover:not(:disabled) { background: var(--border); color: var(--text); }
+
+.fanout-btn--primary {
+  background: var(--accent);
+  color: #fff;
+}
+.fanout-btn--primary:hover:not(:disabled) { background: var(--accent-hover); }
+
+/* ── Fan-out progress panel ───────────────────── */
+.fo-panel-anchor {
+  position: absolute;
+  z-index: 20;
+  pointer-events: auto;
+}
+
+.fo-panel {
+  background: var(--surface);
+  border: 1px solid var(--border);
+  border-radius: var(--radius);
+  box-shadow: 0 8px 32px rgba(0,0,0,0.4);
+  width: 260px;
+  padding: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  animation: peek-in 0.15s ease-out;
+}
+
+.fo-panel--success { border-color: var(--green); }
+.fo-panel--failure { border-color: var(--orange); }
+
+.fo-panel__header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.fo-panel__title {
+  font-size: 12px;
+  font-weight: 700;
+  color: var(--text);
+  flex: 1;
+}
+
+.fo-panel__progress-label {
+  font-size: 11px;
+  color: var(--text-dim);
+  white-space: nowrap;
+}
+
+.fo-panel__dismiss {
+  background: none;
+  border: none;
+  color: var(--text-dim);
+  font-size: 12px;
+  cursor: pointer;
+  padding: 0 2px;
+  line-height: 1;
+  flex-shrink: 0;
+}
+.fo-panel__dismiss:hover { color: var(--text); }
+
+.fo-task-list {
+  list-style: none;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.fo-task {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 6px;
+  border-radius: 6px;
+  cursor: pointer;
+  transition: background 0.1s;
+  font-size: 12px;
+}
+.fo-task:hover { background: var(--surface2); }
+
+.fo-task__icon {
+  font-size: 11px;
+  width: 14px;
+  text-align: center;
+  flex-shrink: 0;
+}
+
+.fo-task--queued  .fo-task__icon { color: var(--text-dim); }
+.fo-task--running .fo-task__icon { color: var(--accent); animation: fo-pulse 1.2s ease-in-out infinite; }
+.fo-task--done    .fo-task__icon { color: var(--green); }
+.fo-task--failed  .fo-task__icon { color: var(--red); }
+
+@keyframes fo-pulse {
+  0%, 100% { opacity: 1; }
+  50%       { opacity: 0.3; }
+}
+
+.fo-task__avatar {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  font-size: 8px;
+  font-weight: 700;
+  color: #fff;
+  flex-shrink: 0;
+}
+
+.fo-task__name {
+  flex: 1;
+  color: var(--text);
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.fo-task__label {
+  font-size: 10px;
+  color: var(--text-dim);
+  white-space: nowrap;
+  flex-shrink: 0;
+}
+
+.fo-task--done   .fo-task__label { color: var(--green); }
+.fo-task--failed .fo-task__label { color: var(--red); }
+
+.fo-task__hint {
+  font-size: 10px;
+  color: var(--red);
+  opacity: 0.7;
+  flex-shrink: 0;
+}
+
+.fo-panel__progress-bar {
+  height: 4px;
+  background: var(--surface2);
+  border-radius: 2px;
+  overflow: hidden;
+}
+
+.fo-panel__progress-fill {
+  height: 100%;
+  background: var(--accent);
+  border-radius: 2px;
+  transition: width 0.4s ease;
+}
+
+.fo-panel--success .fo-panel__progress-fill { background: var(--green); }
+.fo-panel--failure .fo-panel__progress-fill { background: var(--orange); }
+
+.fo-panel__pct {
+  font-size: 10px;
+  color: var(--text-dim);
+  text-align: right;
+}
+
+/* broadcasting toast */
+.toast--broadcasting { border-left: 3px solid #8b5cf6; }

--- a/client/src/store/agentStore.ts
+++ b/client/src/store/agentStore.ts
@@ -1,5 +1,5 @@
 import { create } from 'zustand';
-import type { Agent, AgentStatus, ConversationSession, FanOutProposal, Message, Team } from '../types';
+import type { Agent, AgentStatus, ConversationSession, FanOutProposal, FanOutState, FanOutTaskStatus, Message, Team } from '../types';
 
 export interface ToolEvent {
   type: 'call' | 'result';
@@ -33,6 +33,7 @@ interface AgentStore {
   agentHistories: Map<string, Message[]>;
   agentSessions: Map<string, ConversationSession[]>;
   pendingFanOut: FanOutProposal | null;
+  activeFanOuts: Map<string, FanOutState>; // keyed by fanoutId
 
   setAgents: (agents: Agent[]) => void;
   addAgent: (agent: Agent) => void;
@@ -57,6 +58,11 @@ interface AgentStore {
   clearDelegationEvents: (agentId: string) => void;
   setAgentSessions: (agentId: string, sessions: ConversationSession[]) => void;
   setPendingFanOut: (proposal: FanOutProposal | null) => void;
+  // FanOut tracking
+  addFanOut: (state: FanOutState) => void;
+  updateFanOutTaskStatus: (fanoutId: string, taskId: string, status: FanOutTaskStatus, completedAt?: number) => void;
+  settleFanOut: (fanoutId: string) => void;
+  dismissFanOut: (fanoutId: string) => void;
 }
 
 export const useAgentStore = create<AgentStore>((set) => ({
@@ -72,6 +78,7 @@ export const useAgentStore = create<AgentStore>((set) => ({
   agentHistories: new Map(),
   agentSessions: new Map(),
   pendingFanOut: null,
+  activeFanOuts: new Map(),
 
   setAgents: (agents) => set((s) => ({
     agents: [...agents].sort((a, b) => a.roomId.localeCompare(b.roomId)),
@@ -216,4 +223,43 @@ export const useAgentStore = create<AgentStore>((set) => ({
     }),
 
   setPendingFanOut: (proposal) => set({ pendingFanOut: proposal }),
+
+  addFanOut: (fanOut) =>
+    set((state) => {
+      const next = new Map(state.activeFanOuts);
+      next.set(fanOut.fanoutId, fanOut);
+      return { activeFanOuts: next };
+    }),
+
+  updateFanOutTaskStatus: (fanoutId, taskId, status, completedAt) =>
+    set((state) => {
+      const fanOut = state.activeFanOuts.get(fanoutId);
+      if (!fanOut) return {};
+      const next = new Map(state.activeFanOuts);
+      next.set(fanoutId, {
+        ...fanOut,
+        tasks: fanOut.tasks.map((t) =>
+          t.taskId === taskId
+            ? { ...t, status, ...(status === 'running' ? { startedAt: Date.now() } : {}), ...(completedAt ? { completedAt } : {}) }
+            : t
+        ),
+      });
+      return { activeFanOuts: next };
+    }),
+
+  settleFanOut: (fanoutId) =>
+    set((state) => {
+      const fanOut = state.activeFanOuts.get(fanoutId);
+      if (!fanOut) return {};
+      const next = new Map(state.activeFanOuts);
+      next.set(fanoutId, { ...fanOut, settled: true });
+      return { activeFanOuts: next };
+    }),
+
+  dismissFanOut: (fanoutId) =>
+    set((state) => {
+      const next = new Map(state.activeFanOuts);
+      next.delete(fanoutId);
+      return { activeFanOuts: next };
+    }),
 }));

--- a/client/src/store/socketStore.ts
+++ b/client/src/store/socketStore.ts
@@ -2,14 +2,15 @@ import { create } from 'zustand';
 import { io, Socket } from 'socket.io-client';
 import { useAgentStore } from './agentStore';
 import { useToastStore } from './toastStore';
-import type { Agent, AgentStatus, ConversationSession, FanOutProposal, Message, Team } from '../types';
+import type { Agent, AgentStatus, ConversationSession, FanOutDispatchedPayload, FanOutProposal, FanOutTaskCompletePayload, FanOutTaskStartedPayload, FanOutCompletePayload, Message, Team } from '../types';
 import { playPending, playSleeping, playWorking, playDelegating } from '../utils/sounds';
 
 const STATUS_LABELS: Record<AgentStatus, string> = {
-  working:    '⚙️ Working…',
-  pending:    '❗ Needs your input',
-  sleeping:   '💤 Done',
-  delegating: '📨 Waiting for agent',
+  working:      '⚙️ Working…',
+  pending:      '❗ Needs your input',
+  sleeping:     '💤 Done',
+  delegating:   '📨 Waiting for agent',
+  broadcasting: '📡 Broadcasting fan-out',
 };
 
 function notifyStatusChange(agentId: string, status: AgentStatus, pendingQuestion?: string) {
@@ -207,6 +208,45 @@ export const useSocketStore = create<SocketStore>((set, get) => ({
 
     socket.on('agent:fanOutProposal', (proposal: FanOutProposal) => {
       useAgentStore.getState().setPendingFanOut(proposal);
+    });
+
+    // ── FanOut lifecycle events ─────────────────────────────────────────────
+
+    socket.on('fanout:dispatched', ({ fanoutId, sourceAgentId, tasks }: FanOutDispatchedPayload) => {
+      useAgentStore.getState().addFanOut({
+        fanoutId,
+        sourceAgentId,
+        tasks: tasks.map((t) => ({ ...t, status: 'queued' })),
+        startedAt: Date.now(),
+        settled: false,
+      });
+    });
+
+    socket.on('fanout:taskStarted', ({ fanoutId, taskId }: FanOutTaskStartedPayload) => {
+      useAgentStore.getState().updateFanOutTaskStatus(fanoutId, taskId, 'running');
+    });
+
+    socket.on('fanout:taskComplete', ({ fanoutId, taskId, status }: FanOutTaskCompletePayload) => {
+      useAgentStore.getState().updateFanOutTaskStatus(fanoutId, taskId, status, Date.now());
+    });
+
+    socket.on('fanout:complete', ({ fanoutId, sourceAgentId, results }: FanOutCompletePayload) => {
+      const store = useAgentStore.getState();
+      store.settleFanOut(fanoutId);
+
+      const total = results.length;
+      const done = results.filter((r) => r.status === 'done').length;
+      const failed = total - done;
+      const sourceAgent = store.agents.find((a) => a.id === sourceAgentId);
+      const name = sourceAgent?.name ?? 'Fan-out';
+
+      if (failed === 0) {
+        useToastStore.getState().push({ agentId: sourceAgentId, agentName: name, avatarColor: sourceAgent?.avatarColor ?? '#8b5cf6', status: 'sleeping', customMessage: `Fan-out complete — ${done}/${total} tasks done` });
+      } else if (done === 0) {
+        useToastStore.getState().push({ agentId: sourceAgentId, agentName: name, avatarColor: sourceAgent?.avatarColor ?? '#8b5cf6', status: 'sleeping', customMessage: `Fan-out failed — 0/${total} done` });
+      } else {
+        useToastStore.getState().push({ agentId: sourceAgentId, agentName: name, avatarColor: sourceAgent?.avatarColor ?? '#8b5cf6', status: 'sleeping', customMessage: `Fan-out partial — ${done}/${total} done, ${failed} failed` });
+      }
     });
 
     set({ socket });

--- a/client/src/store/toastStore.ts
+++ b/client/src/store/toastStore.ts
@@ -8,6 +8,7 @@ export interface Toast {
   avatarColor: string;
   status: AgentStatus;
   pendingQuestion?: string;
+  customMessage?: string;
 }
 
 interface ToastStore {

--- a/client/src/types.ts
+++ b/client/src/types.ts
@@ -1,4 +1,4 @@
-export type AgentStatus = 'sleeping' | 'working' | 'pending' | 'delegating';
+export type AgentStatus = 'sleeping' | 'working' | 'pending' | 'delegating' | 'broadcasting';
 
 export interface WorkspaceSyncConfig {
   remoteUrl?: string;
@@ -104,4 +104,54 @@ export interface FanOutProposal {
   fromAgentId: string;
   teamId: string;
   tasks: FanOutTask[];
+}
+
+// ── Live FanOut tracking ──────────────────────────────────────────────────────
+
+export type FanOutTaskStatus = 'queued' | 'running' | 'done' | 'failed';
+
+export interface FanOutTaskState {
+  taskId: string;
+  targetAgentId: string;
+  taskSnippet: string;
+  status: FanOutTaskStatus;
+  startedAt?: number;
+  completedAt?: number;
+}
+
+export interface FanOutState {
+  fanoutId: string;
+  sourceAgentId: string;
+  tasks: FanOutTaskState[];
+  startedAt: number;
+  /** true once all tasks have settled (done or failed) */
+  settled: boolean;
+}
+
+// ── Socket event payloads ─────────────────────────────────────────────────────
+
+export interface FanOutDispatchedPayload {
+  fanoutId: string;
+  sourceAgentId: string;
+  tasks: Array<{ taskId: string; targetAgentId: string; taskSnippet: string }>;
+}
+
+export interface FanOutTaskStartedPayload {
+  fanoutId: string;
+  taskId: string;
+  targetAgentId: string;
+}
+
+export interface FanOutTaskCompletePayload {
+  fanoutId: string;
+  taskId: string;
+  targetAgentId: string;
+  status: 'done' | 'failed';
+  summary?: string;
+}
+
+export interface FanOutCompletePayload {
+  fanoutId: string;
+  sourceAgentId: string;
+  results: Array<{ taskId: string; status: 'done' | 'failed' }>;
 }

--- a/server/src/models/types.ts
+++ b/server/src/models/types.ts
@@ -1,4 +1,4 @@
-export type AgentStatus = 'sleeping' | 'working' | 'pending' | 'delegating';
+export type AgentStatus = 'sleeping' | 'working' | 'pending' | 'delegating' | 'broadcasting';
 
 export interface GitSync {
   remoteUrl: string;

--- a/server/src/routes/fanOut.ts
+++ b/server/src/routes/fanOut.ts
@@ -1,4 +1,5 @@
 import { Router } from 'express';
+import { randomUUID } from 'crypto';
 import type { Server } from 'socket.io';
 import { pendingFanOuts, runAgentTask } from '../services/claudeService.js';
 import * as agentService from '../services/agentService.js';
@@ -17,29 +18,82 @@ export function createFanOutRouter(io: Server): Router {
 
     pendingFanOuts.delete(proposal.id);
 
-    // Fire tasks in batches — cap concurrency to avoid API rate limits
+    const fanoutId = randomUUID();
+
+    interface ResolvedTask {
+      taskId: string;
+      targetAgentId: string;
+      taskSnippet: string;
+      prompt: string;
+    }
+
+    const resolvedTasks: ResolvedTask[] = proposal.tasks.flatMap((task) => {
+      const target = agentService.findAgentByName(task.agent, proposal.teamId);
+      if (!target) {
+        console.warn(`[fan-out] agent "${task.agent}" not found at dispatch time — skipping`);
+        return [];
+      }
+      return [{
+        taskId: randomUUID(),
+        targetAgentId: target.id,
+        taskSnippet: task.prompt.slice(0, 120),
+        prompt: task.prompt,
+      }];
+    });
+
+    if (resolvedTasks.length === 0) {
+      res.status(422).json({ error: 'No resolvable targets' });
+      return;
+    }
+
+    // Emit fanout:dispatched immediately so the client can render the progress panel
+    io.emit('fanout:dispatched', {
+      fanoutId,
+      sourceAgentId: proposal.fromAgentId,
+      tasks: resolvedTasks.map(({ taskId, targetAgentId, taskSnippet }) => ({
+        taskId,
+        targetAgentId,
+        taskSnippet,
+      })),
+    });
+
+    // Source agent enters broadcasting status while tasks run
+    agentService.setStatus(proposal.fromAgentId, 'broadcasting');
+    io.emit('agent:statusChanged', { agentId: proposal.fromAgentId, status: 'broadcasting' });
+
     const dispatchAll = async () => {
-      for (let i = 0; i < proposal.tasks.length; i += CONCURRENCY_LIMIT) {
-        const batch = proposal.tasks.slice(i, i + CONCURRENCY_LIMIT);
+      const results: Array<{ taskId: string; status: 'done' | 'failed' }> = [];
+
+      for (let i = 0; i < resolvedTasks.length; i += CONCURRENCY_LIMIT) {
+        const batch = resolvedTasks.slice(i, i + CONCURRENCY_LIMIT);
         await Promise.all(
-          batch.map((task) => {
-            const target = agentService.findAgentByName(task.agent, proposal.teamId);
-            if (!target) {
-              console.warn(`[fan-out] agent "${task.agent}" not found at dispatch time — skipping`);
-              return Promise.resolve();
+          batch.map(async ({ taskId, targetAgentId, prompt }) => {
+            io.emit('fanout:taskStarted', { fanoutId, taskId, targetAgentId });
+            try {
+              await runAgentTask(targetAgentId, io, prompt);
+              io.emit('fanout:taskComplete', { fanoutId, taskId, targetAgentId, status: 'done' });
+              results.push({ taskId, status: 'done' });
+            } catch (err) {
+              console.error(`[fan-out] task ${taskId} failed:`, err);
+              io.emit('fanout:taskComplete', { fanoutId, taskId, targetAgentId, status: 'failed' });
+              results.push({ taskId, status: 'failed' });
             }
-            return runAgentTask(target.id, io, task.prompt);
           })
         );
       }
+
+      agentService.setStatus(proposal.fromAgentId, 'sleeping');
+      io.emit('agent:statusChanged', { agentId: proposal.fromAgentId, status: 'sleeping' });
+      io.emit('fanout:complete', { fanoutId, sourceAgentId: proposal.fromAgentId, results });
     };
 
-    // Dispatch asynchronously — don't block the HTTP response
     dispatchAll().catch((err) => {
-      console.error('[fan-out] dispatch error:', err);
+      console.error('[fan-out] dispatchAll error:', err);
+      agentService.setStatus(proposal.fromAgentId, 'sleeping');
+      io.emit('agent:statusChanged', { agentId: proposal.fromAgentId, status: 'sleeping' });
     });
 
-    res.json({ dispatched: proposal.tasks.length });
+    res.json({ dispatched: resolvedTasks.length, fanoutId });
   });
 
   router.post('/:proposalId/reject', (req, res) => {

--- a/server/src/services/notifyService.ts
+++ b/server/src/services/notifyService.ts
@@ -2,10 +2,11 @@ import { execFile } from 'child_process';
 import type { AgentStatus } from '../models/types.js';
 
 const STATUS_LABELS: Record<AgentStatus, string> = {
-  working:    '⚙️ Working…',
-  pending:    '❗ Needs your input',
-  sleeping:   '💤 Done',
-  delegating: '📨 Waiting for agent',
+  working:      '⚙️ Working…',
+  pending:      '❗ Needs your input',
+  sleeping:     '💤 Done',
+  delegating:   '📨 Waiting for agent',
+  broadcasting: '📡 Broadcasting fan-out',
 };
 
 export function notifyDesktop(agentName: string, status: AgentStatus, pendingQuestion?: string): void {


### PR DESCRIPTION
Closes #54

## Summary

Full implementation of the fan-out visual experience per the spec.

### Backend
- `'broadcasting'` added to `AgentStatus` (server + client types)
- `fanOut.ts` now assigns a `fanoutId`, emits four new Socket.IO events, and manages the source agent's status lifecycle:
  - `fanout:dispatched` — emitted immediately on confirm, before tasks run
  - `fanout:taskStarted` — per task, when execution begins
  - `fanout:taskComplete` — per task, with `status: 'done' | 'failed'`
  - `fanout:complete` — when all tasks have settled

### Board canvas
- **Broadcasting room**: purple pulsing border (1.8 s ease-in-out) + `📡 Fan-out` badge top-right
- **Fan lines**: one marching-dash line per active target, colored by the *target* agent's avatar color; red static line for failed tasks
- **Fan-out halo**: SVG `<rect>` drawn behind the dispatching room + all active target rooms (purple 4% fill, 1 px dashed 20% border, 12 px radius)

### Confirmation dialog (`FanOutModal`)
- Header: dispatching agent avatar + "Dispatch parallel tasks?" title
- Task cards: agent avatar, name, prompt text (2-line clamp + ▾ expand), `⚠ busy` badge if target is `working` or `pending`
- Footer: `[Cancel]` / `[Dispatch N tasks →]`

### Progress panel (`FanOutProgressPanel`)
- Anchored 8 px below the dispatching agent's room
- Per-task rows: icon (○ / ● pulsing / ✓ / ✕) + avatar + name + elapsed label
- Progress bar + % counter
- On all-success: border turns green, auto-collapses after 4 s
- On any failure: border orange, stays open; `✕` to dismiss manually
- Clicking a row opens that agent's chat

### Toast notifications
- `fanout:complete` listener pushes a contextual toast:
  - All done: `Fan-out complete — N/N tasks done`
  - Partial: `Fan-out partial — N/M done, X failed`
  - All failed: `Fan-out failed — 0/N done`
- `customMessage` field added to `Toast` so arbitrary text can override the status label

## Test plan
- [ ] Agent emits `<FAN_OUT>` → confirmation dialog shows structured task cards with agent avatars and expand/collapse
- [ ] Busy badge appears on a target agent that is already `working`
- [ ] On dispatch: source agent room shows purple pulsing border + `📡 Fan-out` badge
- [ ] Fan lines appear from source to each target, colored by target avatar color
- [ ] Fan-out halo rect visible around all involved rooms
- [ ] Progress panel slides in below the dispatching room; tasks advance queued → running → done/failed
- [ ] Failed task: line turns red (no animation), row shows ✕ red icon
- [ ] All tasks done: progress bar turns green, panel auto-dismisses after 4 s
- [ ] Partial failure: panel stays open with orange border
- [ ] Toast appears on completion with correct message
- [ ] `✕` dismiss button removes the panel immediately

🤖 Generated with [Claude Code](https://claude.com/claude-code)