### PR TITLE
feat: forward Slack message when agent requires user input

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -22,3 +22,6 @@ try {
 
 export const PORT = Number(process.env.PORT ?? 3001);
 export const READ_ONLY = process.env.READ_ONLY === 'true' || process.env.READ_ONLY === '1';
+export const SLACK_BOT_TOKEN = process.env.SLACK_BOT_TOKEN ?? '';
+export const SLACK_CHANNEL_ID = process.env.SLACK_CHANNEL_ID ?? '';
+export const APP_URL = process.env.APP_URL ?? `http://localhost:${PORT}`;

--- a/server/src/services/claudeService.ts
+++ b/server/src/services/claudeService.ts
@@ -4,7 +4,7 @@ import { randomUUID } from 'crypto';
 import type { Server } from 'socket.io';
 import { query } from '@anthropic-ai/claude-agent-sdk';
 import * as agentService from './agentService.js';
-import { notifyDesktop } from './notifyService.js';
+import { notifyDesktop, notifySlack } from './notifyService.js';
 import type { FanOutProposal, FanOutTask } from '../models/types.js';
 import { emitThrottledStream, emitToZoomedRooms } from './zoomService.js';
 
@@ -431,6 +431,7 @@ export async function runAgentTask(
       agentService.setStatus(agentId, 'pending', question);
       io.emit('agent:statusChanged', { agentId, status: 'pending', pendingQuestion: question });
       notifyDesktop(agent.name, 'pending', question);
+      notifySlack(agent.name, agentId, question);
     } else {
       agentService.setStatus(agentId, 'sleeping');
       io.emit('agent:statusChanged', { agentId, status: 'sleeping' });

--- a/server/src/services/notifyService.ts
+++ b/server/src/services/notifyService.ts
@@ -1,5 +1,6 @@
 import { execFile } from 'child_process';
 import type { AgentStatus } from '../models/types.js';
+import { SLACK_BOT_TOKEN, SLACK_CHANNEL_ID, APP_URL } from '../config.js';
 
 const STATUS_LABELS: Record<AgentStatus, string> = {
   working:    '⚙️ Working…',
@@ -19,4 +20,51 @@ export function notifyDesktop(agentName: string, status: AgentStatus, pendingQue
   execFile('osascript', ['-e', script], (err) => {
     if (err) console.warn('[notify] osascript failed:', err.message);
   });
+}
+
+export function notifySlack(agentName: string, agentId: string, question: string): void {
+  if (!SLACK_BOT_TOKEN || !SLACK_CHANNEL_ID) return;
+
+  const deepLink = `${APP_URL}/#/agents/${agentId}`;
+  const payload = {
+    channel: SLACK_CHANNEL_ID,
+    text: `*${agentName}* needs your input`,
+    blocks: [
+      {
+        type: 'section',
+        text: {
+          type: 'mrkdwn',
+          text: `*${agentName}* — ❗ Needs your input\n\n${question}`,
+        },
+      },
+      {
+        type: 'actions',
+        elements: [
+          {
+            type: 'button',
+            text: { type: 'plain_text', text: 'Open chat' },
+            url: deepLink,
+          },
+        ],
+      },
+    ],
+  };
+
+  fetch('https://slack.com/api/chat.postMessage', {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'Authorization': `Bearer ${SLACK_BOT_TOKEN}`,
+    },
+    body: JSON.stringify(payload),
+  })
+    .then((res) => res.json())
+    .then((body: unknown) => {
+      if (typeof body === 'object' && body !== null && !(body as { ok: boolean }).ok) {
+        console.warn('[notify] Slack postMessage error:', (body as { error?: string }).error);
+      }
+    })
+    .catch((err: unknown) => {
+      console.warn('[notify] Slack postMessage failed:', err instanceof Error ? err.message : String(err));
+    });
 }


### PR DESCRIPTION
## Summary
- Uses Slack Web API (`chat.postMessage`) with a bot token — no Incoming Webhook dependency
- When an agent emits `<NEED_INPUT>`, posts a Block Kit message to the configured channel with the agent name, question text, and an "Open chat" button deep-linking to `/#/agents/<agentId>`
- Silently no-ops if `SLACK_BOT_TOKEN` or `SLACK_CHANNEL_ID` are unset

## Required env vars
```
SLACK_BOT_TOKEN=xoxb-...
SLACK_CHANNEL_ID=C01234567
APP_URL=https://your-app.example.com   # optional, defaults to http://localhost:<PORT>
```

The bot needs the `chat:write` scope on the target channel.

## Test plan
- [ ] Set both env vars, trigger an agent that emits `<NEED_INPUT>` — verify message appears in the channel with correct agent name, question, and working deep-link
- [ ] Leave vars unset — verify server starts and no error is thrown

Closes #59

🤖 Generated with [Claude Code](https://claude.com/claude-code)