### PR TITLE
fix: reset FanOutModal step on each new proposal (closes #61)

### DIFF
--- a/client/src/components/FanOutModal.tsx
+++ b/client/src/components/FanOutModal.tsx
@@ -1,4 +1,4 @@
-import { useState } from 'react';
+import { useEffect, useState } from 'react';
 import { useAgentStore } from '../store/agentStore';
 import { TTL_OPTIONS } from '../utils/ttl';
 
@@ -22,6 +22,17 @@ export function FanOutModal() {
   const [expandedTasks, setExpandedTasks] = useState<Set<number>>(new Set());
   const [selectedCron, setSelectedCron] = useState(CRON_OPTIONS[1].cron);
   const [selectedTtlMs, setSelectedTtlMs] = useState(TTL_OPTIONS[1].ms);
+
+  // Reset step and transient state whenever a new proposal arrives.
+  // Without this, `step` stays 'cron' from the previous interaction and the
+  // confirmation dialog is skipped for subsequent FAN_OUT dispatches.
+  useEffect(() => {
+    if (proposal) {
+      setStep('confirm');
+      setError(null);
+      setExpandedTasks(new Set());
+    }
+  }, [proposal?.id]);
 
   if (!proposal) return null;
 


### PR DESCRIPTION
## Root cause

`FanOutModal` is a persistent component that returns `null` when there is no active proposal (rather than unmounting). After the user confirms a dispatch, the component sets `step = 'cron'`. When the proposal is dismissed (Skip / Set up cron), `setPendingFanOut(null)` clears the proposal, but the `step` state stays `'cron'` inside the still-mounted component.

When a subsequent `agent:fanOutProposal` event arrives, `pendingFanOut` becomes non-null again and the component renders — but with `step === 'cron'`, showing the post-dispatch cron-scheduling screen instead of the confirmation dialog. The user never gets a chance to confirm the second dispatch, so it is silently dropped.

## Fix

Add a `useEffect` keyed on `proposal.id` that resets `step`, `error`, and `expandedTasks` whenever a new proposal arrives. One-line summary: the confirmation dialog is now always shown for every new proposal, regardless of the previous interaction's state.

## Test plan

- [ ] Trigger a first FAN_OUT from an agent — confirm the dispatch → cron step appears → click Skip
- [ ] Trigger a second FAN_OUT from the same agent — confirm the confirmation dialog (not cron step) appears
- [ ] Confirm the second dispatch — tasks should be dispatched correctly
- [ ] Reject a FAN_OUT — modal dismisses, next FAN_OUT still shows confirmation dialog

🤖 Generated with [Claude Code](https://claude.com/claude-code)