### PR TITLE
fix: office board size consistent regardless of agent count

### DIFF
--- a/client/src/components/HUD.tsx
+++ b/client/src/components/HUD.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useAgentStore } from '../store/agentStore';
 import { requestDesktopNotifications } from '../store/socketStore';
+import { GRID_CAPACITY } from '../constants';
 
 interface Props {
   onAddAgent: () => void;
@@ -18,8 +19,7 @@ export function HUD({ onAddAgent, onOpenTemplates, onOpenSync, connected, readOn
     (acc, a) => { acc[a.status] = (acc[a.status] ?? 0) + 1; return acc; },
     {} as Record<string, number>,
   );
-  const ROOMS_PER_TEAM = 10;
-  const full = teamAgentCount >= ROOMS_PER_TEAM;
+  const full = teamAgentCount >= GRID_CAPACITY;
   const [notifPerm, setNotifPerm] = useState<NotificationPermission>('default');
   const [title, setTitle] = useState(() => localStorage.getItem('app-title') ?? 'Tonkatsu');
   const [editingTitle, setEditingTitle] = useState(false);
@@ -106,7 +106,7 @@ export function HUD({ onAddAgent, onOpenTemplates, onOpenSync, connected, readOn
             className="btn btn-primary"
             onClick={onAddAgent}
             disabled={full}
-            title={full ? `All ${ROOMS_PER_TEAM} offices occupied` : 'Create a new agent'}
+            title={full ? `All ${GRID_CAPACITY} offices occupied` : 'Create a new agent'}
           >
             + Add Agent
           </button>

--- a/client/src/components/OfficeMap.tsx
+++ b/client/src/components/OfficeMap.tsx
@@ -3,9 +3,8 @@ import { useAgentStore } from '../store/agentStore';
 import { useSocketStore } from '../store/socketStore';
 import { Room } from './Room';
 import type { Agent, Room as RoomType } from '../types';
+import { GRID_COLS, GRID_ROWS } from '../constants';
 
-const GRID_COLS = 5;
-const GRID_ROWS = 3;
 const ROOMS: RoomType[] = Array.from({ length: GRID_COLS * GRID_ROWS }, (_, i) => ({
   id: `room-${String(i + 1).padStart(2, '0')}`,
   agentId: null,

--- a/client/src/constants.ts
+++ b/client/src/constants.ts
@@ -1,0 +1,4 @@
+/** Grid dimensions — single source of truth for the office board. */
+export const GRID_COLS = 5;
+export const GRID_ROWS = 3;
+export const GRID_CAPACITY = GRID_COLS * GRID_ROWS; // 15

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -271,6 +271,8 @@ html, body, #root {
   display: grid;
   grid-template-columns: repeat(5, 1fr);
   grid-template-rows: repeat(3, 160px);
+  /* min-height pins the board at full capacity even when rows are all-vacant */
+  min-height: calc(3 * 160px + 2 * 14px);
   gap: 14px;
   width: min(900px, 100%);
   position: relative;


### PR DESCRIPTION
## Summary

- Add `client/src/constants.ts` with `GRID_COLS=5`, `GRID_ROWS=3`, `GRID_CAPACITY=15` — single source of truth for board dimensions
- **Root cause**: `HUD.tsx` had `ROOMS_PER_TEAM = 10` (hardcoded). The grid is 5×3 = 15 slots, so agents 11–15 were permanently blocked from being created, and those 5 rooms were always empty/unreachable
- `OfficeMap.tsx` already rendered all 15 rooms via static array; now imports from constants to prevent future drift
- `index.css`: add `min-height: calc(3 * 160px + 2 * 14px)` to `.office-grid` so the board cannot visually collapse even when all rooms are vacant

## Test plan

- [ ] With 0 agents: board renders full 5×3 grid (15 vacant placeholder slots)
- [ ] With 10 agents: "Add Agent" button is still enabled (was incorrectly disabled before this fix)
- [ ] With 15 agents: "Add Agent" disables, tooltip says "All 15 offices occupied"
- [ ] Full team still renders correctly — no regression on occupied rooms

Closes #71

🤖 Generated with [Claude Code](https://claude.com/claude-code)