### PR TITLE
fix: push Docker image to Docker Hub instead of GHCR

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_dispatch:
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -43,7 +43,6 @@ jobs:
       contents: write
       issues: write
       pull-requests: write
-      packages: write
     outputs:
       new_release_published: ${{ steps.semantic.outputs.new_release_published }}
       new_release_version: ${{ steps.semantic.outputs.new_release_version }}
@@ -79,17 +78,16 @@ jobs:
     if: needs.release.outputs.new_release_published == 'true'
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,7 +5,7 @@ on:
     branches: [main]
 
 env:
-  REGISTRY: ghcr.io
+  REGISTRY: docker.io
   IMAGE_NAME: ${{ github.repository }}
 
 jobs:
@@ -42,17 +42,16 @@ jobs:
     needs: lint-test-build
     permissions:
       contents: read
-      packages: write
 
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to GitHub Container Registry
+      - name: Log in to Docker Hub
         uses: docker/login-action@v3
         with:
-          registry: ${{ env.REGISTRY }}
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          registry: docker.io
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3


### PR DESCRIPTION
## Summary
- Replace `ghcr.io` with `docker.io` as the container registry in both `release.yml` and `manual-release.yml`
- Update login step to use `DOCKERHUB_USERNAME` / `DOCKERHUB_TOKEN` secrets instead of `GITHUB_TOKEN`
- Remove `packages: write` permission from docker jobs (no longer needed)

## Required setup
Add two secrets to the repo before this pipeline runs:
- `DOCKERHUB_USERNAME`
- `DOCKERHUB_TOKEN`

## Test plan
- [ ] Merge to `main` and verify CI pushes image to `docker.io/pierredosne-fin/tonkatsu-ai`
- [ ] Trigger manual release and verify versioned tags appear on Docker Hub

🤖 Generated with [Claude Code](https://claude.com/claude-code)