### PR TITLE
fix: hardcode Docker Hub image name to pdosne/tonkatsu-ai

### DIFF
--- a/.github/workflows/manual-release.yml
+++ b/.github/workflows/manual-release.yml
@@ -5,7 +5,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: pdosne/tonkatsu-ai
 
 jobs:
   lint-test-build:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,7 +6,7 @@ on:
 
 env:
   REGISTRY: docker.io
-  IMAGE_NAME: ${{ github.repository }}
+  IMAGE_NAME: pdosne/tonkatsu-ai
 
 jobs:
   lint-test-build:


### PR DESCRIPTION
## Summary
- Replace `${{ github.repository }}` with `pdosne/tonkatsu-ai` as the hardcoded image name in both `release.yml` and `manual-release.yml`
- Follows up on #74 which switched the registry to Docker Hub but left the image name dynamic (which would resolve to `pierredosne-fin/tonkatsu-ai`, not the correct Docker Hub repo)

## Test plan
- [ ] Merge and verify CI pushes to `docker.io/pdosne/tonkatsu-ai`

🤖 Generated with [Claude Code](https://claude.com/claude-code)