### PR TITLE
fix: static office cell sizes

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -269,10 +269,10 @@ html, body, #root {
 
 .office-grid {
   display: grid;
-  grid-template-columns: repeat(5, 1fr);
+  grid-template-columns: repeat(5, 160px);
   grid-template-rows: repeat(3, 160px);
   gap: 14px;
-  width: min(900px, 100%);
+  width: fit-content;
   position: relative;
 }
 


### PR DESCRIPTION
## Summary
- Office cells were shrinking when a team had few agents because `grid-template-columns: repeat(5, 1fr)` made columns proportional to container width
- Container width could vary based on layout state, causing inconsistent cell sizes
- Fixed by using `repeat(5, 160px)` (fixed columns) and `width: fit-content` — cells are now always 160×160px

## Test plan
- [ ] Create a new team with 1 agent — offices should be the same size as a full board
- [ ] Resize viewport — office cells should stay 160×160px

🤖 Generated with [Claude Code](https://claude.com/claude-code)